### PR TITLE
HeaderProcessor 추가하고 그것을 사용하도록 수정

### DIFF
--- a/ExcelColumnExtractor/Checkers/DataBodyChecker.cs
+++ b/ExcelColumnExtractor/Checkers/DataBodyChecker.cs
@@ -1,5 +1,8 @@
-using ExcelColumnExtractor.Aggregator;
+using System.Globalization;
+using System.Text;
 using ExcelColumnExtractor.Containers;
+using ExcelColumnExtractor.Exceptions;
+using ExcelColumnExtractor.HeaderProcessors;
 using Microsoft.Extensions.Logging;
 using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Schemata;
@@ -9,10 +12,31 @@ namespace ExcelColumnExtractor.Checkers;
 public static class DataBodyChecker
 {
     public static void Check(
-        IReadOnlyList<RawRecordSchema> staticDataRecordSchemaList,
+        IReadOnlyList<RawRecordSchema> recordSchemaList,
         RecordSchemaContainer recordSchemaContainer,
         ExtractedTableContainer extractedTableContainer,
+        HeaderLengthContainer headerLengthContainer,
         ILogger<Program> logger)
     {
+        var sb = new StringBuilder();
+        foreach (var recordSchema in recordSchemaList)
+        {
+            try
+            {
+            }
+            catch (Exception e)
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"{recordSchema}: {e.Message}");
+                LogError(logger, recordSchema, e.Message, e);
+            }
+        }
+
+        if (sb.Length > 0)
+        {
+            throw new DataBodyCheckerException(sb.ToString());
+        }
     }
+
+    private static readonly Action<ILogger, RawRecordSchema, string, Exception?> LogError =
+        LoggerMessage.Define<RawRecordSchema, string>(LogLevel.Error, new EventId(0, nameof(LogError)), "{RecordSchema}: {ErrorMessage}");
 }

--- a/ExcelColumnExtractor/Containers/ExcelSheetNameContainer.cs
+++ b/ExcelColumnExtractor/Containers/ExcelSheetNameContainer.cs
@@ -6,8 +6,7 @@ using StaticDataAttribute;
 
 namespace ExcelColumnExtractor.Containers;
 
-public sealed class ExcelSheetNameContainer(
-    IReadOnlyDictionary<string, ExcelSheetName> sheetNames)
+public sealed class ExcelSheetNameContainer(IReadOnlyDictionary<string, ExcelSheetName> sheetNames)
 {
     public int Count => sheetNames.Count;
 

--- a/ExcelColumnExtractor/Exceptions/BodyColumnAggregatorException.cs
+++ b/ExcelColumnExtractor/Exceptions/BodyColumnAggregatorException.cs
@@ -1,0 +1,3 @@
+namespace ExcelColumnExtractor.Exceptions;
+
+public class BodyColumnAggregatorException(string message) : Exception(message);

--- a/ExcelColumnExtractor/Exceptions/DataBodyCheckerException.cs
+++ b/ExcelColumnExtractor/Exceptions/DataBodyCheckerException.cs
@@ -1,0 +1,3 @@
+namespace ExcelColumnExtractor.Exceptions;
+
+public class DataBodyCheckerException(string message) : Exception(message);

--- a/ExcelColumnExtractor/HeaderProcessors/HeaderLengthBuilder.cs
+++ b/ExcelColumnExtractor/HeaderProcessors/HeaderLengthBuilder.cs
@@ -1,0 +1,43 @@
+using ExcelColumnExtractor.Containers;
+using ExcelColumnExtractor.Scanners;
+using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
+using SchemaInfoScanner.Extensions;
+using SchemaInfoScanner.Schemata;
+
+namespace ExcelColumnExtractor.HeaderProcessors;
+
+public static class HeaderLengthBuilder
+{
+    public static HeaderLengthContainer Build(
+        IReadOnlyList<RawRecordSchema> staticDataRecordSchemaList,
+        RecordSchemaContainer recordSchemaContainer,
+        ExcelSheetNameContainer sheetNameContainer,
+        ILogger logger)
+    {
+        var headerLengths = new Dictionary<RawRecordSchema, IReadOnlyDictionary<string, int>>();
+        foreach (var rawRecordSchema in staticDataRecordSchemaList)
+        {
+            try
+            {
+                var excelSheetName = sheetNameContainer.Get(rawRecordSchema);
+                var sheetHeaders = SheetHeaderScanner.Scan(excelSheetName, logger);
+                var lengthRequiredNames = rawRecordSchema.DetectLengthRequiringFields(recordSchemaContainer);
+                var containerLengths = HeaderLengthParser.Parse(sheetHeaders, lengthRequiredNames);
+
+                headerLengths.Add(rawRecordSchema, containerLengths);
+            }
+            catch (Exception e)
+            {
+                // TODO 이거 불필요한지 확인되면 빼자
+                var msg = $"{rawRecordSchema.RecordName.FullName}: {e.Message}";
+                LogError(logger, rawRecordSchema, msg, e);
+            }
+        }
+
+        return new(headerLengths.AsReadOnly());
+    }
+
+    private static readonly Action<ILogger, RawRecordSchema, string, Exception?> LogError =
+        LoggerMessage.Define<RawRecordSchema, string>(LogLevel.Error, new EventId(0, nameof(LogError)), "{RecordSchema}: {ErrorMessage}");
+}

--- a/ExcelColumnExtractor/HeaderProcessors/HeaderLengthContainer.cs
+++ b/ExcelColumnExtractor/HeaderProcessors/HeaderLengthContainer.cs
@@ -1,0 +1,12 @@
+using System.Collections.ObjectModel;
+using SchemaInfoScanner.Schemata;
+
+namespace ExcelColumnExtractor.HeaderProcessors;
+
+public sealed class HeaderLengthContainer(ReadOnlyDictionary<RawRecordSchema, IReadOnlyDictionary<string, int>> headerLengths)
+{
+    public IReadOnlyDictionary<string, int> Get(RawRecordSchema rawRecordSchema)
+    {
+        return headerLengths[rawRecordSchema];
+    }
+}

--- a/ExcelColumnExtractor/HeaderProcessors/HeaderLengthParser.cs
+++ b/ExcelColumnExtractor/HeaderProcessors/HeaderLengthParser.cs
@@ -1,8 +1,7 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
-using StaticDataAttribute;
 
-namespace ExcelColumnExtractor.Parsers;
+namespace ExcelColumnExtractor.HeaderProcessors;
 
 public static class HeaderLengthParser
 {

--- a/ExcelColumnExtractor/Program.cs
+++ b/ExcelColumnExtractor/Program.cs
@@ -5,6 +5,8 @@ using CLICommonLibrary;
 using CommandLine;
 using ExcelColumnExtractor.Aggregator;
 using ExcelColumnExtractor.Checkers;
+using ExcelColumnExtractor.Containers;
+using ExcelColumnExtractor.HeaderProcessors;
 using ExcelColumnExtractor.Scanners;
 using ExcelColumnExtractor.Writers;
 using Microsoft.Extensions.Logging;
@@ -48,10 +50,20 @@ public class Program
         LogTrace(logger, sw.Elapsed.TotalMilliseconds, nameof(SheetNameScanner), null);
 
         sw.Restart();
+        var headerLengthContainer = HeaderLengthBuilder.Build(
+            staticDataRecordSchemaList,
+            recordSchemaContainer,
+            sheetNameContainer,
+            logger);
+        LogTrace(logger, sw.Elapsed.TotalMilliseconds, nameof(HeaderLengthBuilder), null);
+
+        sw.Restart();
+
         var targetColumnIndicesContainer = RequiredHeadersChecker.Check(
             staticDataRecordSchemaList,
             recordSchemaContainer,
             sheetNameContainer,
+            headerLengthContainer,
             logger);
         LogTrace(logger, sw.Elapsed.TotalMilliseconds, nameof(RequiredHeadersChecker), null);
 
@@ -64,10 +76,13 @@ public class Program
         LogTrace(logger, sw.Elapsed.TotalMilliseconds, nameof(BodyColumnAggregator), null);
 
         sw.Restart();
+
+        // use length
         DataBodyChecker.Check(
             staticDataRecordSchemaList,
             recordSchemaContainer,
             extractedTableContainer,
+            headerLengthContainer,
             logger);
         LogTrace(logger, sw.Elapsed.TotalMilliseconds, nameof(DataBodyChecker), null);
 

--- a/SchemaInfoScanner/Extensions/RecordSchemaParameterFlattener.cs
+++ b/SchemaInfoScanner/Extensions/RecordSchemaParameterFlattener.cs
@@ -17,10 +17,10 @@ public static partial class RecordSchemaParameterFlattener
     public static IReadOnlyList<string> Flatten(
         this RawRecordSchema rawRecordSchema,
         RecordSchemaContainer recordSchemaContainer,
-        IReadOnlyDictionary<string, int> containerLengths,
+        IReadOnlyDictionary<string, int> headerLengths,
         ILogger logger)
     {
-        return OnFlatten(rawRecordSchema, recordSchemaContainer, containerLengths, string.Empty, logger);
+        return OnFlatten(rawRecordSchema, recordSchemaContainer, headerLengths, string.Empty, logger);
     }
 
     private static List<string> OnFlatten(


### PR DESCRIPTION
데이터 유효성 검증 시 Header들의 Length정보가 필요하다.