### PR TITLE
CheckCompatibility에서 enumMemberContainer를 반드시 넣도록 수정

### DIFF
--- a/SchemaInfoScanner/Schemata/ParameterSchemaBase.cs
+++ b/SchemaInfoScanner/Schemata/ParameterSchemaBase.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 
 namespace SchemaInfoScanner.Schemata;
@@ -10,21 +11,16 @@ public abstract record ParameterSchemaBase(
     INamedTypeSymbol NamedTypeSymbol,
     IReadOnlyList<AttributeSyntax> AttributeList)
 {
-    public bool IsNullable()
-    {
-        return NamedTypeSymbol.OriginalDefinition.SpecialType is SpecialType.System_Nullable_T;
-    }
-
     public override string ToString()
     {
         return ParameterName.FullName;
     }
 
-    public void CheckCompatibility(string argument, ILogger logger)
+    public void CheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         try
         {
-            OnCheckCompatibility(argument, logger);
+            OnCheckCompatibility(argument, enumMemberContainer, logger);
         }
         catch (Exception e)
         {
@@ -32,7 +28,7 @@ public abstract record ParameterSchemaBase(
         }
     }
 
-    protected abstract void OnCheckCompatibility(string argument, ILogger logger);
+    protected abstract void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger);
 
     private static readonly Action<ILogger, Type, string, Exception?> LogError =
         LoggerMessage.Define<Type, string>(

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/BooleanParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/BooleanParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 
 namespace SchemaInfoScanner.Schemata.TypedParameterSchemata;
@@ -11,7 +12,7 @@ public sealed record BooleanParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         _ = bool.Parse(argument);
     }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/ByteParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/ByteParameterSchema.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Extensions;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
@@ -15,7 +16,7 @@ public sealed record ByteParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var value = byte.Parse(argument, CultureInfo.InvariantCulture);
 

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/CharParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/CharParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Extensions;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
@@ -14,7 +15,7 @@ public sealed record CharParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var value = char.Parse(argument);
 

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/DecimalParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/DecimalParameterSchema.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Extensions;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
@@ -15,7 +16,7 @@ public sealed record DecimalParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var value = decimal.Parse(argument, CultureInfo.InvariantCulture);
 

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/DoubleParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/DoubleParameterSchema.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Extensions;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
@@ -15,7 +16,7 @@ public sealed record DoubleParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var value = double.Parse(argument, CultureInfo.InvariantCulture);
 

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/EnumParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/EnumParameterSchema.cs
@@ -12,22 +12,13 @@ public sealed record EnumParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
-    {
-        throw new InvalidOperationException($"{ParameterName.FullName} is enum. Use CheckCompatibility(string, EnumMemberContainer, ILogger) instead");
-    }
-
-    public void CheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var enumName = new EnumName(NamedTypeSymbol.Name);
         var enumMembers = enumMemberContainer.GetEnumMembers(enumName);
         if (!enumMembers.Contains(argument))
         {
-            var ex = new InvalidOperationException($"{argument} is not a member of {enumName.FullName}");
-            LogError(logger, argument, enumName.FullName, ex);
+            throw new InvalidOperationException($"{argument} is not a member of {enumName.FullName}");
         }
     }
-
-    private static readonly Action<ILogger, string, string, Exception?> LogError =
-        LoggerMessage.Define<string, string>(LogLevel.Error, new EventId(0, nameof(LogError)), "{Argument} is not a member of {EnumFullName}");
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/FloatParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/FloatParameterSchema.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Extensions;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
@@ -15,7 +16,7 @@ public sealed record FloatParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var value = float.Parse(argument, CultureInfo.InvariantCulture);
 

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/Int16ParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/Int16ParameterSchema.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Extensions;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
@@ -15,7 +16,7 @@ public sealed record Int16ParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var value = short.Parse(argument, CultureInfo.InvariantCulture);
 

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/Int32ParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/Int32ParameterSchema.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Extensions;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
@@ -15,7 +16,7 @@ public sealed record Int32ParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var value = int.Parse(argument, CultureInfo.InvariantCulture);
 

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/Int64ParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/Int64ParameterSchema.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Extensions;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
@@ -15,7 +16,7 @@ public sealed record Int64ParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var value = long.Parse(argument, CultureInfo.InvariantCulture);
 

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableBooleanParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableBooleanParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableBooleanParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableBooleanParameterSchema(
         }
 
         var schema = new BooleanParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableByteParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableByteParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableByteParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableByteParameterSchema(
         }
 
         var schema = new ByteParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableCharParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableCharParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableCharParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableCharParameterSchema(
         }
 
         var schema = new CharParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableDecimalParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableDecimalParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableDecimalParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableDecimalParameterSchema(
         }
 
         var schema = new DecimalParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableDoubleParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableDoubleParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableDoubleParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableDoubleParameterSchema(
         }
 
         var schema = new DoubleParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableEnumParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableEnumParameterSchema.cs
@@ -13,12 +13,7 @@ public sealed record NullableEnumParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
-    {
-        throw new InvalidOperationException($"{ParameterName.FullName} is nullable enum. Use CheckCompatibility(string, EnumMemberContainer) instead.");
-    }
-
-    public void CheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableFloatParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableFloatParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableFloatParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableFloatParameterSchema(
         }
 
         var schema = new FloatParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableInt16ParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableInt16ParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableInt16ParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableInt16ParameterSchema(
         }
 
         var schema = new Int16ParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableInt32ParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableInt32ParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableInt32ParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableInt32ParameterSchema(
         }
 
         var schema = new Int32ParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableInt64ParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableInt64ParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableInt64ParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableInt64ParameterSchema(
         }
 
         var schema = new Int64ParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableSByteParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableSByteParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableSByteParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableSByteParameterSchema(
         }
 
         var schema = new SByteParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableSingleColumnContainerParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableSingleColumnContainerParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -14,7 +15,7 @@ public sealed record NullableSingleColumnContainerParameterSchema(
     ParameterSchemaBase InnerParameterSchema)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -23,6 +24,6 @@ public sealed record NullableSingleColumnContainerParameterSchema(
         }
 
         var schema = new SingleColumnContainerParameterSchema(ParameterName, NamedTypeSymbol, AttributeList, Separator, InnerParameterSchema);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableStringParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableStringParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableStringParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableStringParameterSchema(
         }
 
         var schema = new StringParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableUInt16ParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableUInt16ParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableUInt16ParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableUInt16ParameterSchema(
         }
 
         var schema = new UInt16ParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableUInt32ParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableUInt32ParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableUInt32ParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableUInt32ParameterSchema(
         }
 
         var schema = new UInt32ParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableUInt64ParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/NullableUInt64ParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
 
@@ -12,7 +13,7 @@ public sealed record NullableUInt64ParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var result = NullStringAttributeChecker.Check(this, argument);
         if (result.IsNull)
@@ -21,6 +22,6 @@ public sealed record NullableUInt64ParameterSchema(
         }
 
         var schema = new UInt64ParameterSchema(ParameterName, NamedTypeSymbol, AttributeList);
-        schema.CheckCompatibility(argument, logger);
+        schema.CheckCompatibility(argument, enumMemberContainer, logger);
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/SByteParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/SByteParameterSchema.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Extensions;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
@@ -15,7 +16,7 @@ public sealed record SByteParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var value = sbyte.Parse(argument, CultureInfo.InvariantCulture);
 

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/SingleColumnContainerParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/SingleColumnContainerParameterSchema.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.NameObjects;
 
 namespace SchemaInfoScanner.Schemata.TypedParameterSchemata;
@@ -13,7 +14,7 @@ public sealed record SingleColumnContainerParameterSchema(
     ParameterSchemaBase InnerParameterSchema)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var split = argument
             .Split(Separator)
@@ -21,7 +22,7 @@ public sealed record SingleColumnContainerParameterSchema(
 
         foreach (var item in split)
         {
-            InnerParameterSchema.CheckCompatibility(item, logger);
+            InnerParameterSchema.CheckCompatibility(item, enumMemberContainer, logger);
         }
     }
 }

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/StringParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/StringParameterSchema.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Extensions;
 using SchemaInfoScanner.NameObjects;
 
@@ -14,7 +15,7 @@ public sealed record StringParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         if (!this.TryGetAttributeValue<RegularExpressionAttribute, string>(0, out var pattern))
         {

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/UInt16ParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/UInt16ParameterSchema.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Extensions;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
@@ -15,7 +16,7 @@ public sealed record UInt16ParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var value = ushort.Parse(argument, CultureInfo.InvariantCulture);
 

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/UInt32ParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/UInt32ParameterSchema.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Extensions;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
@@ -15,7 +16,7 @@ public sealed record UInt32ParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var value = uint.Parse(argument, CultureInfo.InvariantCulture);
 

--- a/SchemaInfoScanner/Schemata/TypedParameterSchemata/UInt64ParameterSchema.cs
+++ b/SchemaInfoScanner/Schemata/TypedParameterSchemata/UInt64ParameterSchema.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
+using SchemaInfoScanner.Containers;
 using SchemaInfoScanner.Extensions;
 using SchemaInfoScanner.NameObjects;
 using SchemaInfoScanner.Schemata.AttributeCheckers;
@@ -15,7 +16,7 @@ public sealed record UInt64ParameterSchema(
     IReadOnlyList<AttributeSyntax> AttributeList)
     : ParameterSchemaBase(ParameterName, NamedTypeSymbol, AttributeList)
 {
-    protected override void OnCheckCompatibility(string argument, ILogger logger)
+    protected override void OnCheckCompatibility(string argument, EnumMemberContainer enumMemberContainer, ILogger logger)
     {
         var value = ulong.Parse(argument, CultureInfo.InvariantCulture);
 

--- a/UnitTest/RecordSchemaFactoryTest.cs
+++ b/UnitTest/RecordSchemaFactoryTest.cs
@@ -75,7 +75,7 @@ public class RecordSchemaFactoryTest(ITestOutputHelper testOutputHelper)
             var value = RandomValueGenerator.Generate(TypeConverter.GetSystemTypeName(type));
             var valueStr = value?.ToString() ?? string.Empty;
 
-            parameter.CheckCompatibility(valueStr, logger);
+            parameter.CheckCompatibility(valueStr, enumMemberContainer, logger);
         }
 
         Assert.Empty(logger.Logs);
@@ -207,7 +207,7 @@ public class RecordSchemaFactoryTest(ITestOutputHelper testOutputHelper)
         var argument = string.Join(", ", list);
 
         var parameter = recordSchema.RecordParameterSchemaList[0];
-        parameter.CheckCompatibility(argument, logger);
+        parameter.CheckCompatibility(argument, enumMemberContainer, logger);
 
         Assert.Empty(logger.Logs);
     }


### PR DESCRIPTION
컨테이너 안의 enum 유효성 검사를 위한 구조 변경