### PR TITLE
StaticDataTable 설계 변경

### DIFF
--- a/Sdp/Csv/CsvLoader.cs
+++ b/Sdp/Csv/CsvLoader.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Reflection;
 using System.Text;
 using Sdp.Resources;
 
@@ -7,24 +8,29 @@ namespace Sdp.Csv;
 
 internal static class CsvLoader
 {
-    public static async Task<ImmutableList<TRecord>> LoadAsync<TRecord>(string filePath)
-        where TRecord : notnull
+    private static readonly MethodInfo BuildImmutableListGenericMethod = typeof(CsvLoader)
+        .GetMethod(nameof(BuildImmutableListTyped), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    public static async Task<object> LoadAsync(string filePath, Type recordType)
     {
         var content = await File.ReadAllTextAsync(filePath);
-        return Parse<TRecord>(content, filePath);
+        return Parse(content, recordType, filePath);
     }
 
-    public static ImmutableList<TRecord> Parse<TRecord>(string csvContent, string? filePath = null)
+    public static async Task<ImmutableList<TRecord>> LoadAsync<TRecord>(string filePath)
         where TRecord : notnull
+        => (ImmutableList<TRecord>)await LoadAsync(filePath, typeof(TRecord));
+
+    private static object Parse(string csvContent, Type recordType, string? filePath = null)
     {
         var rows = ParseCsvContent(csvContent);
         if (rows.Count == 0)
         {
-            return ImmutableList<TRecord>.Empty;
+            return BuildEmptyList(recordType);
         }
 
         var headers = rows[0];
-        var builder = ImmutableList.CreateBuilder<TRecord>();
+        var records = new List<object>(rows.Count - 1);
 
         for (var i = 1; i < rows.Count; i++)
         {
@@ -36,8 +42,8 @@ internal static class CsvLoader
 
             try
             {
-                var record = CsvRecordMapper.MapToRecord<TRecord>(headers, values);
-                builder.Add(record);
+                var record = CsvRecordMapper.MapToRecord(recordType, headers, values);
+                records.Add(record);
             }
             catch (Exception ex)
             {
@@ -61,8 +67,22 @@ internal static class CsvLoader
             }
         }
 
-        return builder.ToImmutable();
+        return BuildImmutableList(recordType, records);
     }
+
+    public static ImmutableList<TRecord> Parse<TRecord>(string csvContent, string? filePath = null)
+        where TRecord : notnull
+        => (ImmutableList<TRecord>)Parse(csvContent, typeof(TRecord), filePath);
+
+    private static object BuildImmutableList(Type recordType, List<object> records)
+        => BuildImmutableListGenericMethod.MakeGenericMethod(recordType).Invoke(null, [records])!;
+
+    private static object BuildEmptyList(Type recordType)
+    => BuildImmutableListGenericMethod.MakeGenericMethod(recordType).Invoke(null, [new List<object>()])!;
+
+    private static ImmutableList<T> BuildImmutableListTyped<T>(List<object> records)
+        where T : notnull
+        => records.Cast<T>().ToImmutableList();
 
     private static List<string[]> ParseCsvContent(string content)
     {

--- a/Sdp/Csv/CsvRecordMapper.cs
+++ b/Sdp/Csv/CsvRecordMapper.cs
@@ -6,10 +6,9 @@ namespace Sdp.Csv;
 
 internal static class CsvRecordMapper
 {
-    public static TRecord MapToRecord<TRecord>(string[] headers, string[] values)
-        where TRecord : notnull
+    public static object MapToRecord(Type recordType, string[] headers, string[] values)
     {
-        var typeInfo = CsvTypeCache.GetTypeInfo(typeof(TRecord));
+        var typeInfo = CsvTypeCache.GetTypeInfo(recordType);
         var headerIndexMap = BuildHeaderIndexMap(headers);
         var args = new object?[typeInfo.Parameters.Length];
 
@@ -19,8 +18,12 @@ internal static class CsvRecordMapper
             args[i] = ConvertValue(paramInfo, paramInfo.ColumnName, headerIndexMap, values);
         }
 
-        return (TRecord)typeInfo.Constructor.Invoke(args);
+        return typeInfo.Constructor.Invoke(args)!;
     }
+
+    public static TRecord MapToRecord<TRecord>(string[] headers, string[] values)
+        where TRecord : notnull
+        => (TRecord)MapToRecord(typeof(TRecord), headers, values);
 
     private static Dictionary<string, int> BuildHeaderIndexMap(string[] headers)
     {

--- a/Sdp/Manager/ForeignKeyResolver.cs
+++ b/Sdp/Manager/ForeignKeyResolver.cs
@@ -11,10 +11,22 @@ internal static class ForeignKeyResolver
     {
         var type = typeof(TTableSet);
         var ctor = type.GetConstructors().Single();
-        return ctor.GetParameters()
-            .Select(p => (Name: p.Name!, Table: type.GetProperty(p.Name!)?.GetValue(tableSet) as IStaticDataTable))
-            .Where(x => x.Table is not null)
-            .ToDictionary(x => x.Name, x => x.Table!);
+        var map = new Dictionary<string, IStaticDataTable>();
+
+        foreach (var param in ctor.GetParameters())
+        {
+            var name = param.Name!;
+            var property = type.GetProperty(name);
+
+            if (property?.GetValue(tableSet) is not IStaticDataTable table)
+            {
+                continue;
+            }
+
+            map[name] = table;
+        }
+
+        return map;
     }
 
     internal static bool TryResolveTarget(
@@ -36,8 +48,7 @@ internal static class ForeignKeyResolver
             return false;
         }
 
-        var isPk = columnName == targetTable.PrimaryKeyPropertyName;
-        if (!isPk && targetTable.RecordType.GetProperty(columnName) is null)
+        if (targetTable.RecordType.GetProperty(columnName) is null)
         {
             errors.Add(new InvalidOperationException(string.Format(
                 CultureInfo.CurrentCulture,
@@ -48,7 +59,7 @@ internal static class ForeignKeyResolver
             return false;
         }
 
-        target = new FkTarget(tableSetName, columnName, targetTable, isPk);
+        target = new FkTarget(tableSetName, columnName, targetTable);
         return true;
     }
 
@@ -57,14 +68,8 @@ internal static class ForeignKeyResolver
         object? fkValue,
         Dictionary<(string TargetName, string ColumnName), HashSet<object?>> cache)
     {
-        if (target.IsPrimaryKey)
-        {
-            return target.TargetTable.ContainsPrimaryKey(fkValue);
-        }
-
         var cacheKey = (target.TargetName, target.ColumnName);
 
-        // 첫 조회 시(cache에 값이 없음) target 테이블의 해당 컬럼 전체 값을 조회해서 HashSet cache에 저장
         if (!cache.TryGetValue(cacheKey, out var valueSet))
         {
             var prop = target.TargetTable.RecordType.GetProperty(target.ColumnName)!;
@@ -92,6 +97,5 @@ internal static class ForeignKeyResolver
     internal sealed record FkTarget(
         string TargetName,
         string ColumnName,
-        IStaticDataTable TargetTable,
-        bool IsPrimaryKey);
+        IStaticDataTable TargetTable);
 }

--- a/Sdp/Manager/StaticDataManager.cs
+++ b/Sdp/Manager/StaticDataManager.cs
@@ -1,5 +1,9 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Reflection;
+using Sdp.Attributes;
+using Sdp.Csv;
 using Sdp.Resources;
 using Sdp.Table;
 
@@ -15,35 +19,42 @@ public abstract class StaticDataManager<TTableSet>
     public async Task LoadAsync(string csvDir, List<string>? disabledTables = null)
     {
         var tableSet = await BuildTablesAsync(csvDir, disabledTables);
-
-        var tableMap = ForeignKeyResolver.BuildTableMap(tableSet);
-        ForeignKeyValidator.Validate(tableMap);
-        SwitchForeignKeyValidator.Validate(tableMap);
-
-        Validate(tableSet);
-        current = tableSet;
+        FinalizeLoad(tableSet);
     }
 
     internal void Load(TTableSet tableSet)
     {
-        var tableMap = ForeignKeyResolver.BuildTableMap(tableSet);
-        ForeignKeyValidator.Validate(tableMap);
-        SwitchForeignKeyValidator.Validate(tableMap);
-
-        Validate(tableSet);
-        current = tableSet;
+        FinalizeLoad(tableSet);
     }
 
     protected virtual void Validate(TTableSet tableSet)
     {
     }
 
+    private void FinalizeLoad(TTableSet tableSet)
+    {
+        var tableMap = ForeignKeyResolver.BuildTableMap(tableSet);
+
+        foreach (var table in tableMap.Values)
+        {
+            table.Validate();
+        }
+
+        ForeignKeyValidator.Validate(tableMap);
+        SwitchForeignKeyValidator.Validate(tableMap);
+
+        Validate(tableSet);
+        current = tableSet;
+    }
+
     private static async Task<TTableSet> BuildTablesAsync(string csvDir, List<string>? disabledTables)
     {
         var ctor = typeof(TTableSet).GetConstructors().Single();
         var parameters = ctor.GetParameters();
+        var recordCache = new ConcurrentDictionary<RecordCacheKey, Lazy<Task<object>>>();
+
         var tasks = parameters
-            .Select(p => CreateArgAsync(p, csvDir, disabledTables))
+            .Select(p => CreateTableAsync(p, csvDir, disabledTables, recordCache))
             .ToArray();
 
         try
@@ -68,15 +79,20 @@ public abstract class StaticDataManager<TTableSet>
         return (TTableSet)ctor.Invoke(tasks.Select(t => t.Result).ToArray());
     }
 
-    private static async Task<object?> CreateArgAsync(ParameterInfo param, string csvDir, List<string>? disabledTables)
+    private static async Task<object?> CreateTableAsync(
+        ParameterInfo param,
+        string csvDir,
+        List<string>? disabledTables,
+        ConcurrentDictionary<RecordCacheKey, Lazy<Task<object>>> recordCache)
     {
-        if (!IsStaticDataTable(param.ParameterType))
+        var tableType = param.ParameterType;
+        if (!IsStaticDataTable(tableType))
         {
             throw new InvalidOperationException(string.Format(
                 CultureInfo.CurrentCulture,
                 Messages.Composite.InvalidTableParameter,
                 param.Name!,
-                param.ParameterType.Name));
+                tableType.Name));
         }
 
         if (disabledTables?.Contains(param.Name!) == true)
@@ -84,32 +100,80 @@ public abstract class StaticDataManager<TTableSet>
             return null;
         }
 
-        var method = param.ParameterType.GetMethod(
-            "CreateAsync",
-            BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+        var recordType = ExtractRecordType(tableType);
+        var csvPath = ResolveCsvPath(csvDir, recordType);
 
-        if (method is null)
-        {
-            throw new InvalidOperationException(string.Format(
-                CultureInfo.CurrentCulture,
-                Messages.Composite.CreateAsyncNotFound,
-                param.ParameterType.FullName ?? param.ParameterType.Name));
-        }
+        var lazyTask = recordCache.GetOrAdd(
+            new RecordCacheKey(csvPath, recordType),
+            key => new Lazy<Task<object>>(() => CsvLoader.LoadAsync(key.CsvPath, key.RecordType)));
 
-        Task task;
+        var records = await lazyTask.Value;
+
+        var ctor = FindTableConstructor(tableType, recordType);
         try
         {
-            task = (Task)method.Invoke(null, [csvDir])!;
+            return ctor.Invoke([records]);
         }
         catch (TargetInvocationException tie)
         {
             throw tie.InnerException ?? tie;
         }
-
-        await task;
-        return task.GetType().GetProperty("Result")!.GetValue(task);
     }
 
     private static bool IsStaticDataTable(Type type)
         => typeof(IStaticDataTable).IsAssignableFrom(type);
+
+    private static Type ExtractRecordType(Type tableType)
+    {
+        var current = tableType;
+        while (current is not null && current != typeof(object))
+        {
+            if (current.IsGenericType && current.GetGenericTypeDefinition() == typeof(StaticDataTable<,>))
+            {
+                return current.GetGenericArguments()[1];
+            }
+
+            current = current.BaseType;
+        }
+
+        throw new InvalidOperationException(FormattableString.Invariant(
+            $"{tableType.Name} does not derive from StaticDataTable<,>."));
+    }
+
+    private static string ResolveCsvPath(string csvDir, Type recordType)
+    {
+        var attr = recordType.GetCustomAttribute<StaticDataRecordAttribute>();
+
+        if (attr is null)
+        {
+            throw new InvalidOperationException(string.Format(
+                CultureInfo.CurrentCulture,
+                Messages.Composite.StaticDataRecordAttributeRequired,
+                recordType.Name));
+        }
+
+        var fileName = FormattableString.Invariant($"{attr.ExcelFileName}.{attr.SheetName}.csv");
+        return Path.Combine(csvDir, fileName);
+    }
+
+    private sealed record RecordCacheKey(string CsvPath, Type RecordType);
+
+    private static ConstructorInfo FindTableConstructor(Type tableType, Type recordType)
+    {
+        var paramType = typeof(ImmutableList<>).MakeGenericType(recordType);
+        var ctor = tableType.GetConstructor(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            [paramType]);
+
+        if (ctor is null)
+        {
+            throw new InvalidOperationException(string.Format(
+                CultureInfo.CurrentCulture,
+                Messages.Composite.TableConstructorNotFound,
+                tableType.Name,
+                recordType.Name));
+        }
+
+        return ctor;
+    }
 }

--- a/Sdp/Resources/Messages.Designer.cs
+++ b/Sdp/Resources/Messages.Designer.cs
@@ -30,8 +30,8 @@ internal static class Messages
     internal static string InvalidTableParameter
         => ResourceManager.GetString("InvalidTableParameter", Culture)!;
 
-    internal static string CreateAsyncNotFound
-        => ResourceManager.GetString("CreateAsyncNotFound", Culture)!;
+    internal static string TableConstructorNotFound
+        => ResourceManager.GetString("TableConstructorNotFound", Culture)!;
 
     internal static string FkTargetNotFound
         => ResourceManager.GetString("FkTargetNotFound", Culture)!;
@@ -47,9 +47,6 @@ internal static class Messages
 
     internal static string SwitchFkConditionColumnNotFound
         => ResourceManager.GetString("SwitchFkConditionColumnNotFound", Culture)!;
-
-    internal static string KeySelectorInvalid
-        => ResourceManager.GetString("KeySelectorInvalid", Culture)!;
 
     internal static string StaticDataRecordAttributeRequired
         => ResourceManager.GetString("StaticDataRecordAttributeRequired", Culture)!;
@@ -87,7 +84,7 @@ internal static class Messages
     internal static class Composite
     {
         internal static CompositeFormat InvalidTableParameter => CompositeFormat.Parse(Messages.InvalidTableParameter);
-        internal static CompositeFormat CreateAsyncNotFound => CompositeFormat.Parse(Messages.CreateAsyncNotFound);
+        internal static CompositeFormat TableConstructorNotFound => CompositeFormat.Parse(Messages.TableConstructorNotFound);
         internal static CompositeFormat FkTargetNotFound => CompositeFormat.Parse(Messages.FkTargetNotFound);
         internal static CompositeFormat IndexNotRegistered => CompositeFormat.Parse(Messages.IndexNotRegistered);
         internal static CompositeFormat FkValueNotFound => CompositeFormat.Parse(Messages.FkValueNotFound);

--- a/Sdp/Resources/Messages.ko.resx
+++ b/Sdp/Resources/Messages.ko.resx
@@ -12,14 +12,14 @@
   <data name="InvalidTableParameter" xml:space="preserve">
     <value>'{0}' 파라미터의 타입 '{1}'이(가) StaticDataTable&lt;,&gt; 서브타입이 아닙니다.</value>
   </data>
-  <data name="CreateAsyncNotFound" xml:space="preserve">
-    <value>{0}에 public static CreateAsync(string) 메서드가 없습니다.</value>
+  <data name="TableConstructorNotFound" xml:space="preserve">
+    <value>{0}에는 ImmutableList&lt;{1}&gt;를 받는 생성자가 필요합니다.</value>
   </data>
   <data name="FkTargetNotFound" xml:space="preserve">
     <value>FK 타겟 '{0}'을(를) 찾을 수 없거나 비활성화되어 있습니다.</value>
   </data>
   <data name="IndexNotRegistered" xml:space="preserve">
-    <value>'{1}'에 '{0}' 인덱스가 등록되어 있지 않습니다. FK 타겟으로 사용하려면 생성자에서 RegisterIndex()를 호출하세요.</value>
+    <value>'{1}'에 '{0}' 컬럼이 존재하지 않습니다.</value>
   </data>
   <data name="FkValueNotFound" xml:space="preserve">
     <value>{0}.{1}({2})이(가) [{3}] 중 어디에도 존재하지 않습니다.</value>
@@ -30,11 +30,8 @@
   <data name="SwitchFkConditionColumnNotFound" xml:space="preserve">
     <value>Switch FK 조건 컬럼 '{0}'을(를) {1}에서 찾을 수 없습니다.</value>
   </data>
-  <data name="KeySelectorInvalid" xml:space="preserve">
-    <value>키 셀렉터는 단순 프로퍼티 접근이어야 합니다. (예: x =&gt; x.Id)</value>
-  </data>
   <data name="StaticDataRecordAttributeRequired" xml:space="preserve">
-    <value>{0}은(는) 디렉터리에서 로드할 때 [StaticDataRecord] 어트리뷰트가 필요합니다.</value>
+    <value>{0}에 [StaticDataRecord] 어트리뷰트가 필요합니다.</value>
   </data>
   <data name="DuplicateKey" xml:space="preserve">
     <value>{1}에 중복된 키 '{0}'이(가) 있습니다.</value>

--- a/Sdp/Resources/Messages.resx
+++ b/Sdp/Resources/Messages.resx
@@ -12,14 +12,14 @@
   <data name="InvalidTableParameter" xml:space="preserve">
     <value>Parameter '{0}' of type '{1}' is not a StaticDataTable&lt;,&gt; subtype.</value>
   </data>
-  <data name="CreateAsyncNotFound" xml:space="preserve">
-    <value>{0} does not have a public static CreateAsync(string) method.</value>
+  <data name="TableConstructorNotFound" xml:space="preserve">
+    <value>{0} must have a constructor accepting ImmutableList&lt;{1}&gt;.</value>
   </data>
   <data name="FkTargetNotFound" xml:space="preserve">
     <value>FK target '{0}' not found or disabled.</value>
   </data>
   <data name="IndexNotRegistered" xml:space="preserve">
-    <value>No index registered for '{0}' in {1}. Call RegisterIndex() in the constructor to use it as a FK target.</value>
+    <value>Column '{0}' not found on {1}.</value>
   </data>
   <data name="FkValueNotFound" xml:space="preserve">
     <value>{0}.{1}({2}) not found in any of: [{3}]</value>
@@ -30,11 +30,8 @@
   <data name="SwitchFkConditionColumnNotFound" xml:space="preserve">
     <value>Switch FK condition column '{0}' not found on {1}.</value>
   </data>
-  <data name="KeySelectorInvalid" xml:space="preserve">
-    <value>Key selector must be a simple property access (e.g. x =&gt; x.Id).</value>
-  </data>
   <data name="StaticDataRecordAttributeRequired" xml:space="preserve">
-    <value>{0} requires [StaticDataRecord] attribute when loading from a directory.</value>
+    <value>{0} requires [StaticDataRecord] attribute.</value>
   </data>
   <data name="DuplicateKey" xml:space="preserve">
     <value>Duplicate key '{0}' in {1}.</value>

--- a/Sdp/Table/IStaticDataTable.cs
+++ b/Sdp/Table/IStaticDataTable.cs
@@ -5,7 +5,8 @@ namespace Sdp.Table;
 internal interface IStaticDataTable
 {
     Type RecordType { get; }
-    string PrimaryKeyPropertyName { get; }
+
     IEnumerable GetAllRecords();
-    bool ContainsPrimaryKey(object? value);
+
+    void Validate();
 }

--- a/Sdp/Table/StaticDataTable.cs
+++ b/Sdp/Table/StaticDataTable.cs
@@ -1,111 +1,22 @@
 using System.Collections;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Linq.Expressions;
-using System.Reflection;
-using Sdp.Attributes;
-using Sdp.Csv;
-using Sdp.Resources;
 
 namespace Sdp.Table;
 
-public abstract class StaticDataTable<TSelf, TRecord, TKey> : IStaticDataTable
-    where TSelf : StaticDataTable<TSelf, TRecord, TKey>
+public abstract class StaticDataTable<TSelf, TRecord>(ImmutableList<TRecord> records)
+    : IStaticDataTable
+    where TSelf : StaticDataTable<TSelf, TRecord>
     where TRecord : notnull
-    where TKey : notnull
 {
-    private readonly UniqueIndex<TRecord, TKey> index;
-    private readonly ImmutableList<TRecord> records;
-    private readonly string primaryKeyPropertyName;
-
-    internal StaticDataTable(
-        ImmutableList<TRecord> records,
-        Func<TRecord, TKey> keySelector,
-        string primaryKeyPropertyName)
-    {
-        this.records = records;
-        this.primaryKeyPropertyName = primaryKeyPropertyName;
-        index = new UniqueIndex<TRecord, TKey>(records, keySelector);
-    }
-
-    protected StaticDataTable(
-        ImmutableList<TRecord> records,
-        Expression<Func<TRecord, TKey>> keySelector)
-        : this(records, keySelector.Compile(), ExtractPropertyName(keySelector))
-    {
-    }
-
-    private static string ExtractPropertyName(Expression<Func<TRecord, TKey>> expr)
-    {
-        if (expr.Body is MemberExpression memberExpr)
-        {
-            return memberExpr.Member.Name;
-        }
-
-        throw new ArgumentException(Messages.KeySelectorInvalid, nameof(expr));
-    }
-
-    [SuppressMessage(
-        "Design",
-        "CA1000:Do not declare static members on generic types",
-        Justification = "CRTP 패턴: 서브클래스 이름으로 호출하므로 타입 인자 지정 불필요 (e.g. MyTable.CreateAsync)")]
-    public static async Task<TSelf> CreateAsync(string csvDir)
-    {
-        var records = await LoadRecordsAsync(csvDir);
-
-        var ctor = typeof(TSelf).GetConstructor(
-            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
-            [typeof(ImmutableList<TRecord>)]);
-
-        if (ctor is null)
-        {
-            throw new InvalidOperationException(FormattableString.Invariant(
-                $"{typeof(TSelf).Name} must have a constructor accepting ImmutableList<{typeof(TRecord).Name}>."));
-        }
-
-        var instance = (TSelf)ctor.Invoke([records]);
-        instance.Validate();
-        return instance;
-    }
+    public ImmutableList<TRecord> Records => records;
 
     protected virtual void Validate()
     {
     }
 
-    private static async Task<ImmutableList<TRecord>> LoadRecordsAsync(string path)
-    {
-        if (Directory.Exists(path))
-        {
-            var attr = typeof(TRecord).GetCustomAttribute<StaticDataRecordAttribute>();
-            if (attr is null)
-            {
-                throw new InvalidOperationException(string.Format(
-                    CultureInfo.CurrentCulture,
-                    Messages.Composite.StaticDataRecordAttributeRequired,
-                    typeof(TRecord).Name));
-            }
-
-            path = Path.Combine(path, FormattableString.Invariant($"{attr.ExcelFileName}.{attr.SheetName}.csv"));
-        }
-
-        return await CsvLoader.LoadAsync<TRecord>(path);
-    }
-
-    public IReadOnlyList<TRecord> Records => records;
-
-    public TRecord Get(TKey key)
-        => index.Get(key);
-
-    public bool TryGet(TKey key, [NotNullWhen(true)] out TRecord? record)
-        => index.TryGet(key, out record);
-
     Type IStaticDataTable.RecordType => typeof(TRecord);
-
-    string IStaticDataTable.PrimaryKeyPropertyName => primaryKeyPropertyName;
 
     IEnumerable IStaticDataTable.GetAllRecords() => records;
 
-    bool IStaticDataTable.ContainsPrimaryKey(object? value)
-        => value is TKey typedKey && index.TryGet(typedKey, out _);
+    void IStaticDataTable.Validate() => Validate();
 }

--- a/UnitTest/ForeignKeyTests/ForeignKeyValidationTests.cs
+++ b/UnitTest/ForeignKeyTests/ForeignKeyValidationTests.cs
@@ -69,28 +69,43 @@ public class ForeignKeyValidationTests
         [ForeignKey("School", "Id")] int SchoolId,
         [ForeignKey("Teacher", "Id")] int TeacherId);
 
-    private sealed class SchoolTable : StaticDataTable<SchoolTable, School, int>
+    private sealed class SchoolTable : StaticDataTable<SchoolTable, School>
     {
+        private readonly UniqueIndex<School, int> byId;
+
         public SchoolTable(ImmutableList<School> records)
-            : base(records, x => x.Id, "Id")
+            : base(records)
         {
+            byId = new(records, x => x.Id);
         }
+
+        public School Get(int id) => byId.Get(id);
     }
 
-    private sealed class TeacherTable : StaticDataTable<TeacherTable, Teacher, int>
+    private sealed class TeacherTable : StaticDataTable<TeacherTable, Teacher>
     {
+        private readonly UniqueIndex<Teacher, int> byId;
+
         public TeacherTable(ImmutableList<Teacher> records)
-            : base(records, x => x.Id, "Id")
+            : base(records)
         {
+            byId = new(records, x => x.Id);
         }
+
+        public Teacher Get(int id) => byId.Get(id);
     }
 
-    private sealed class StudentTable : StaticDataTable<StudentTable, Student, int>
+    private sealed class StudentTable : StaticDataTable<StudentTable, Student>
     {
+        private readonly UniqueIndex<Student, int> byId;
+
         public StudentTable(ImmutableList<Student> records)
-            : base(records, x => x.Id, "Id")
+            : base(records)
         {
+            byId = new(records, x => x.Id);
         }
+
+        public Student Get(int id) => byId.Get(id);
     }
 
     private sealed class StaticData : StaticDataManager<StaticData.TableSet>
@@ -121,9 +136,6 @@ public class ForeignKeyValidationTests
                 new(CsvLoader.Parse<School>(SchoolCsv)),
                 new(CsvLoader.Parse<Teacher>(TeacherCsv)),
                 new(CsvLoader.Parse<Student>(ErrorStudentCsv))));
-
-        public void Load(SchoolTable school, TeacherTable teacher, StudentTable? student = null)
-            => Load(new TableSet(school, teacher, student));
     }
 
     [Fact]

--- a/UnitTest/ForeignKeyTests/MultipleForeignKeyValidationTests.cs
+++ b/UnitTest/ForeignKeyTests/MultipleForeignKeyValidationTests.cs
@@ -56,29 +56,14 @@ public class MultipleForeignKeyValidationTests
         [ForeignKey("Teacher", "Id")]
         int RecipientId);
 
-    private sealed class SchoolTable : StaticDataTable<SchoolTable, School, int>
-    {
-        public SchoolTable(ImmutableList<School> records)
-            : base(records, x => x.Id, "Id")
-        {
-        }
-    }
+    private sealed class SchoolTable(ImmutableList<School> records)
+        : StaticDataTable<SchoolTable, School>(records);
 
-    private sealed class TeacherTable : StaticDataTable<TeacherTable, Teacher, int>
-    {
-        public TeacherTable(ImmutableList<Teacher> records)
-            : base(records, x => x.Id, "Id")
-        {
-        }
-    }
+    private sealed class TeacherTable(ImmutableList<Teacher> records)
+        : StaticDataTable<TeacherTable, Teacher>(records);
 
-    private sealed class ScholarshipTable : StaticDataTable<ScholarshipTable, Scholarship, int>
-    {
-        public ScholarshipTable(ImmutableList<Scholarship> records)
-            : base(records, x => x.Id, "Id")
-        {
-        }
-    }
+    private sealed class ScholarshipTable(ImmutableList<Scholarship> records)
+        : StaticDataTable<ScholarshipTable, Scholarship>(records);
 
     private sealed class StaticData : StaticDataManager<StaticData.TableSet>
     {

--- a/UnitTest/ForeignKeyTests/SwitchForeignKeyNonKeyValidationTests.cs
+++ b/UnitTest/ForeignKeyTests/SwitchForeignKeyNonKeyValidationTests.cs
@@ -52,29 +52,14 @@ public class SwitchForeignKeyNonKeyValidationTests
     private record Engineer(int Id, string Name);
     private record Designer(int Id, string Name);
 
-    private sealed class StaffTable : StaticDataTable<StaffTable, Staff, int>
-    {
-        public StaffTable(ImmutableList<Staff> records)
-            : base(records, x => x.Id, "Id")
-        {
-        }
-    }
+    private sealed class StaffTable(ImmutableList<Staff> records)
+        : StaticDataTable<StaffTable, Staff>(records);
 
-    private sealed class EngineerTable : StaticDataTable<EngineerTable, Engineer, int>
-    {
-        public EngineerTable(ImmutableList<Engineer> records)
-            : base(records, x => x.Id, "Id")
-        {
-        }
-    }
+    private sealed class EngineerTable(ImmutableList<Engineer> records)
+        : StaticDataTable<EngineerTable, Engineer>(records);
 
-    private sealed class DesignerTable : StaticDataTable<DesignerTable, Designer, int>
-    {
-        public DesignerTable(ImmutableList<Designer> records)
-            : base(records, x => x.Id, "Id")
-        {
-        }
-    }
+    private sealed class DesignerTable(ImmutableList<Designer> records)
+        : StaticDataTable<DesignerTable, Designer>(records);
 
     private sealed class StaticData : StaticDataManager<StaticData.TableSet>
     {

--- a/UnitTest/ForeignKeyTests/SwitchForeignKeyValidationTests.cs
+++ b/UnitTest/ForeignKeyTests/SwitchForeignKeyValidationTests.cs
@@ -79,37 +79,17 @@ public class SwitchForeignKeyValidationTests
     private record Character(int Id, string Name);
     private record Currency(int Id, string Name);
 
-    private sealed class QuestTable : StaticDataTable<QuestTable, Quest, int>
-    {
-        public QuestTable(ImmutableList<Quest> records)
-            : base(records, x => x.QuestId, "QuestId")
-        {
-        }
-    }
+    private sealed class QuestTable(ImmutableList<Quest> records)
+        : StaticDataTable<QuestTable, Quest>(records);
 
-    private sealed class ItemTable : StaticDataTable<ItemTable, Item, int>
-    {
-        public ItemTable(ImmutableList<Item> records)
-            : base(records, x => x.Id, "Id")
-        {
-        }
-    }
+    private sealed class ItemTable(ImmutableList<Item> records)
+        : StaticDataTable<ItemTable, Item>(records);
 
-    private sealed class CharacterTable : StaticDataTable<CharacterTable, Character, int>
-    {
-        public CharacterTable(ImmutableList<Character> records)
-            : base(records, x => x.Id, "Id")
-        {
-        }
-    }
+    private sealed class CharacterTable(ImmutableList<Character> records)
+        : StaticDataTable<CharacterTable, Character>(records);
 
-    private sealed class CurrencyTable : StaticDataTable<CurrencyTable, Currency, int>
-    {
-        public CurrencyTable(ImmutableList<Currency> records)
-            : base(records, x => x.Id, "Id")
-        {
-        }
-    }
+    private sealed class CurrencyTable(ImmutableList<Currency> records)
+        : StaticDataTable<CurrencyTable, Currency>(records);
 
     private sealed class StaticData : StaticDataManager<StaticData.TableSet>
     {
@@ -219,21 +199,11 @@ public class SwitchForeignKeyConfigurationErrorTests
 
     private record Target(int Id);
 
-    private sealed class BadConditionQuestTable : StaticDataTable<BadConditionQuestTable, BadConditionQuest, int>
-    {
-        public BadConditionQuestTable(ImmutableList<BadConditionQuest> records)
-            : base(records, x => x.Id, "Id")
-        {
-        }
-    }
+    private sealed class BadConditionQuestTable(ImmutableList<BadConditionQuest> records)
+        : StaticDataTable<BadConditionQuestTable, BadConditionQuest>(records);
 
-    private sealed class TargetTable : StaticDataTable<TargetTable, Target, int>
-    {
-        public TargetTable(ImmutableList<Target> records)
-            : base(records, x => x.Id, "Id")
-        {
-        }
-    }
+    private sealed class TargetTable(ImmutableList<Target> records)
+        : StaticDataTable<TargetTable, Target>(records);
 
     private sealed class ConditionColumnStaticData : StaticDataManager<ConditionColumnStaticData.TableSet>
     {
@@ -263,13 +233,8 @@ public class SwitchForeignKeyConfigurationErrorTests
         [SwitchForeignKey("RewardType", "Item", "NonExistentTable", "Id")]
         int RewardId);
 
-    private sealed class BadTargetQuestTable : StaticDataTable<BadTargetQuestTable, BadTargetQuest, int>
-    {
-        public BadTargetQuestTable(ImmutableList<BadTargetQuest> records)
-            : base(records, x => x.Id, "Id")
-        {
-        }
-    }
+    private sealed class BadTargetQuestTable(ImmutableList<BadTargetQuest> records)
+        : StaticDataTable<BadTargetQuestTable, BadTargetQuest>(records);
 
     private sealed class TargetTableStaticData : StaticDataManager<TargetTableStaticData.TableSet>
     {

--- a/UnitTest/StaticDataTests/FilteredRecordTableTests.cs
+++ b/UnitTest/StaticDataTests/FilteredRecordTableTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Immutable;
+using Sdp.Attributes;
+using Sdp.Manager;
+using Sdp.Table;
+
+namespace UnitTest.StaticDataTests;
+
+public class FilteredRecordTableTests
+{
+    private const string BuffCsv =
+        """
+        Id,Name,IsNormal
+        1,Haste,true
+        2,Poison,false
+        3,Shield,true
+        4,Curse,false
+        """;
+
+    [StaticDataRecord("Buff", "Main")]
+    private record Buff(int Id, string Name, bool IsNormal);
+
+    private sealed class NormalBuffTable(ImmutableList<Buff> records)
+        : StaticDataTable<NormalBuffTable, Buff>(records.Where(x => x.IsNormal).ToImmutableList());
+
+    private sealed class AbnormalBuffTable(ImmutableList<Buff> records)
+        : StaticDataTable<AbnormalBuffTable, Buff>(records.Where(x => !x.IsNormal).ToImmutableList());
+
+    private sealed class StaticData : StaticDataManager<StaticData.TableSet>
+    {
+        public sealed record TableSet(
+            NormalBuffTable Normal,
+            AbnormalBuffTable Abnormal);
+
+        public NormalBuffTable NormalTable => Current.Normal;
+        public AbnormalBuffTable AbnormalTable => Current.Abnormal;
+    }
+
+    [Fact]
+    public async Task SameRecord_TwoTables_FilterIntoSubsets()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            WriteCsv(dir, "Buff.Main.csv", BuffCsv);
+
+            var staticData = new StaticData();
+            await staticData.LoadAsync(dir);
+
+            Assert.Equal(2, staticData.NormalTable.Records.Count);
+            Assert.All(staticData.NormalTable.Records, x => Assert.True(x.IsNormal));
+
+            Assert.Equal(2, staticData.AbnormalTable.Records.Count);
+            Assert.All(staticData.AbnormalTable.Records, x => Assert.False(x.IsNormal));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    private static string CreateTempDir()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void WriteCsv(string dir, string fileName, string content)
+        => File.WriteAllText(Path.Combine(dir, fileName), content);
+}

--- a/UnitTest/StaticDataTests/SharedCsvTableTests.cs
+++ b/UnitTest/StaticDataTests/SharedCsvTableTests.cs
@@ -1,0 +1,73 @@
+using System.Collections.Immutable;
+using Sdp.Attributes;
+using Sdp.Manager;
+using Sdp.Table;
+
+namespace UnitTest.StaticDataTests;
+
+public class SharedCsvTableTests
+{
+    private const string UnitCsv =
+        """
+        Id,Name,Hp,Attack,Description
+        1,Goblin,100,10,Small green creature
+        2,Dragon,1000,100,Ancient terror
+        """;
+
+    [StaticDataRecord("Unit", "Main")]
+    private record UnitStat(int Id, int Hp, int Attack);
+
+    [StaticDataRecord("Unit", "Main")]
+    private record UnitProfile(int Id, string Name, string Description);
+
+    private sealed class UnitStatTable(ImmutableList<UnitStat> records)
+        : StaticDataTable<UnitStatTable, UnitStat>(records);
+
+    private sealed class UnitProfileTable(ImmutableList<UnitProfile> records)
+        : StaticDataTable<UnitProfileTable, UnitProfile>(records);
+
+    private sealed class StaticData : StaticDataManager<StaticData.TableSet>
+    {
+        public sealed record TableSet(
+            UnitStatTable Stats,
+            UnitProfileTable Profiles);
+
+        public UnitStatTable StatTable => Current.Stats;
+        public UnitProfileTable ProfileTable => Current.Profiles;
+    }
+
+    [Fact]
+    public async Task DifferentRecords_SameCsv_PickDifferentColumns()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            WriteCsv(dir, "Unit.Main.csv", UnitCsv);
+
+            var staticData = new StaticData();
+            await staticData.LoadAsync(dir);
+
+            Assert.Equal(2, staticData.StatTable.Records.Count);
+            Assert.Equal(100, staticData.StatTable.Records[0].Hp);
+            Assert.Equal(10, staticData.StatTable.Records[0].Attack);
+
+            Assert.Equal(2, staticData.ProfileTable.Records.Count);
+            Assert.Equal("Goblin", staticData.ProfileTable.Records[0].Name);
+            Assert.Equal("Small green creature", staticData.ProfileTable.Records[0].Description);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    private static string CreateTempDir()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void WriteCsv(string dir, string fileName, string content)
+        => File.WriteAllText(Path.Combine(dir, fileName), content);
+}

--- a/UnitTest/StaticDataTests/SharedRecordTableTests.cs
+++ b/UnitTest/StaticDataTests/SharedRecordTableTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Immutable;
+using Sdp.Attributes;
+using Sdp.Manager;
+using Sdp.Table;
+
+namespace UnitTest.StaticDataTests;
+
+public class SharedRecordTableTests
+{
+    private const string ItemCsv =
+        """
+        Id,Name
+        1,Alpha
+        2,Beta
+        3,Gamma
+        """;
+
+    [StaticDataRecord("Item", "Main")]
+    private record Item(int Id, string Name);
+
+    private sealed class PrimaryItemTable : StaticDataTable<PrimaryItemTable, Item>
+    {
+        private readonly UniqueIndex<Item, int> byId;
+
+        public PrimaryItemTable(ImmutableList<Item> records)
+            : base(records)
+        {
+            byId = new(records, x => x.Id);
+        }
+
+        public Item Get(int id) => byId.Get(id);
+    }
+
+    private sealed class SecondaryItemTable : StaticDataTable<SecondaryItemTable, Item>
+    {
+        private readonly UniqueIndex<Item, string> byName;
+
+        public SecondaryItemTable(ImmutableList<Item> records)
+            : base(records)
+        {
+            byName = new(records, x => x.Name);
+        }
+
+        public Item Get(string name) => byName.Get(name);
+    }
+
+    private sealed class StaticData : StaticDataManager<StaticData.TableSet>
+    {
+        public sealed record TableSet(
+            PrimaryItemTable Primary,
+            SecondaryItemTable Secondary);
+
+        public PrimaryItemTable PrimaryTable => Current.Primary;
+        public SecondaryItemTable SecondaryTable => Current.Secondary;
+    }
+
+    [Fact]
+    public async Task SameRecordType_DifferentTables_CoexistInTableSet()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            WriteCsv(dir, "Item.Main.csv", ItemCsv);
+
+            var staticData = new StaticData();
+            await staticData.LoadAsync(dir);
+
+            Assert.Equal("Beta", staticData.PrimaryTable.Get(2).Name);
+            Assert.Equal(3, staticData.SecondaryTable.Get("Gamma").Id);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    private static string CreateTempDir()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void WriteCsv(string dir, string fileName, string content)
+        => File.WriteAllText(Path.Combine(dir, fileName), content);
+}

--- a/UnitTest/StaticDataTests/StaticDataManagerTests.cs
+++ b/UnitTest/StaticDataTests/StaticDataManagerTests.cs
@@ -8,41 +8,32 @@ public class StaticDataManagerTests
 {
     private sealed record FakeRecord(int Id);
 
-    private sealed class FakeTable : StaticDataTable<FakeTable, FakeRecord, int>
-    {
-        public const string VersionA = "a";
-        public const string VersionB = "b";
-        public const int CountA = 3;
-        public const int CountB = 7;
-
-        private FakeTable(ImmutableList<FakeRecord> records)
-            : base(records, r => r.Id)
-        {
-        }
-
-        public static new async Task<FakeTable> CreateAsync(string version)
-        {
-            await Task.Delay(50);
-            var count = version == VersionB ? CountB : CountA;
-            var records = Enumerable.Range(1, count)
-                .Select(i => new FakeRecord(i))
-                .ToImmutableList();
-            return new(records);
-        }
-    }
+    private sealed class FakeTable(ImmutableList<FakeRecord> records)
+        : StaticDataTable<FakeTable, FakeRecord>(records);
 
     private sealed class FakeManager : StaticDataManager<FakeManager.TableSet>
     {
         public sealed record TableSet(FakeTable? Items);
 
         public TableSet Tables => Current;
+
+        public void Load(int count)
+        {
+            var records = Enumerable.Range(1, count)
+                .Select(i => new FakeRecord(i))
+                .ToImmutableList();
+            Load(new TableSet(new FakeTable(records)));
+        }
     }
 
     [Fact]
-    public async Task ConcurrentLoadAndRead_AlwaysSeesCompleteDataset()
+    public void ConcurrentLoadAndRead_AlwaysSeesCompleteDataset()
     {
+        const int CountA = 3;
+        const int CountB = 7;
+
         var manager = new FakeManager();
-        await manager.LoadAsync(FakeTable.VersionA);
+        manager.Load(CountA);
 
         var cts = new CancellationTokenSource();
 
@@ -51,7 +42,7 @@ public class StaticDataManagerTests
             var toggle = false;
             while (!cts.Token.IsCancellationRequested)
             {
-                manager.LoadAsync(toggle ? FakeTable.VersionB : FakeTable.VersionA).GetAwaiter().GetResult();
+                manager.Load(toggle ? CountB : CountA);
                 toggle = !toggle;
             }
         });
@@ -62,8 +53,8 @@ public class StaticDataManagerTests
         {
             var count = manager.Tables.Items?.Records.Count;
             Assert.True(
-                count == FakeTable.CountA || count == FakeTable.CountB,
-                FormattableString.Invariant($"예상: {FakeTable.CountA} 또는 {FakeTable.CountB}, 실제: {count}"));
+                count == CountA || count == CountB,
+                FormattableString.Invariant($"예상: {CountA} 또는 {CountB}, 실제: {count}"));
         }
 
         cts.Cancel();

--- a/UnitTest/StaticDataTests/StaticDataTableTests.cs
+++ b/UnitTest/StaticDataTests/StaticDataTableTests.cs
@@ -8,22 +8,31 @@ public class StaticDataTableTests
     private sealed record Item(int Id, string Name);
 
     private sealed class ItemTable(ImmutableList<Item> records)
-        : StaticDataTable<ItemTable, Item, int>(records, r => r.Id);
+        : StaticDataTable<ItemTable, Item>(records);
 
-    private static ItemTable CreateTable()
+    private sealed class IndexedItemTable : StaticDataTable<IndexedItemTable, Item>
     {
-        var records = ImmutableList.Create(
+        private readonly UniqueIndex<Item, int> byId;
+
+        public IndexedItemTable(ImmutableList<Item> records)
+            : base(records)
+        {
+            byId = new(records, x => x.Id);
+        }
+
+        public Item Get(int id) => byId.Get(id);
+    }
+
+    private static ImmutableList<Item> SampleRecords()
+        => ImmutableList.Create(
             new Item(1, "Alpha"),
             new Item(2, "Beta"),
             new Item(3, "Gamma"));
 
-        return new ItemTable(records);
-    }
-
     [Fact]
     public void Records_ReturnsAllRecordsInInsertionOrder()
     {
-        var table = CreateTable();
+        var table = new ItemTable(SampleRecords());
 
         Assert.Equal(3, table.Records.Count);
         Assert.Equal(1, table.Records[0].Id);
@@ -32,70 +41,34 @@ public class StaticDataTableTests
     }
 
     [Fact]
-    public void Get_ExistingKey_ReturnsRecord()
+    public void BaseTable_DoesNotEnforcePrimaryKeyIndex()
     {
-        var table = CreateTable();
+        var duplicated = ImmutableList.Create(
+            new Item(1, "Alpha"),
+            new Item(1, "Duplicate"));
+
+        var table = new ItemTable(duplicated);
+
+        Assert.Equal(2, table.Records.Count);
+    }
+
+    [Fact]
+    public void Subclass_WithUniqueIndex_ProvidesLookup()
+    {
+        var table = new IndexedItemTable(SampleRecords());
 
         var record = table.Get(2);
 
-        Assert.Equal(2, record.Id);
         Assert.Equal("Beta", record.Name);
     }
 
     [Fact]
-    public void Get_MissingKey_ThrowsKeyNotFoundException()
+    public void Subclass_WithUniqueIndex_DuplicateKey_ThrowsInvalidOperationException()
     {
-        var table = CreateTable();
-
-        Assert.Throws<KeyNotFoundException>(() => table.Get(99));
-    }
-
-    [Fact]
-    public void TryGet_ExistingKey_ReturnsTrueAndRecord()
-    {
-        var table = CreateTable();
-
-        var result = table.TryGet(1, out var record);
-
-        Assert.True(result);
-        Assert.NotNull(record);
-        Assert.Equal("Alpha", record.Name);
-    }
-
-    [Fact]
-    public void TryGet_MissingKey_ReturnsFalse()
-    {
-        var table = CreateTable();
-
-        var result = table.TryGet(99, out var record);
-
-        Assert.False(result);
-        Assert.Null(record);
-    }
-
-    [Fact]
-    public void Constructor_DuplicateKey_ThrowsInvalidOperationException()
-    {
-        var records = ImmutableList.Create(
+        var duplicated = ImmutableList.Create(
             new Item(1, "Alpha"),
             new Item(1, "Duplicate"));
 
-        Assert.Throws<InvalidOperationException>(() => new ItemTable(records));
-    }
-
-    [Fact]
-    public void Constructor_NonPropertyKeySelector_ThrowsArgumentException()
-    {
-        var records = ImmutableList<Item>.Empty;
-
-        Assert.Throws<ArgumentException>(() => new NonPropertyKeyTable(records));
-    }
-
-    private sealed class NonPropertyKeyTable : StaticDataTable<NonPropertyKeyTable, Item, int>
-    {
-        public NonPropertyKeyTable(ImmutableList<Item> records)
-            : base(records, r => r.Id + 1)
-        {
-        }
+        Assert.Throws<InvalidOperationException>(() => new IndexedItemTable(duplicated));
     }
 }


### PR DESCRIPTION
### 수정사항
- StaticDataTable의 생성자에서 records를 받도록 수정
- StaticDataTable의 제너릭에서 UniqueIndex의 Key를 받도록 한 부분 수정 (모든 Index는 하위클래스 재량)

### 유닛테스트 추가
- SharedCsvTableTests : 같은 csv, 다른 record를 사용하는 테이블 테스트
- SharedRecordTableTests: 같은 csv, 같은 record를 사용하는 테이블 테스트
- FilteredRecordTableTest : 같은 csv, 같은 record를 사용하는 row가 다른 테이블 테스트