### PR TITLE
테이블 로드 시간 측정 로깅 추가

### DIFF
--- a/Sdp/Manager/StaticDataManager.cs
+++ b/Sdp/Manager/StaticDataManager.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using Sdp.Attributes;
 using Sdp.Csv;
 using Sdp.Resources;
@@ -9,7 +11,7 @@ using Sdp.Table;
 
 namespace Sdp.Manager;
 
-public abstract class StaticDataManager<TTableSet>
+public abstract class StaticDataManager<TTableSet>(ILogger logger)
     where TTableSet : class
 {
     private volatile TTableSet current = null!;
@@ -18,31 +20,41 @@ public abstract class StaticDataManager<TTableSet>
 
     public async Task LoadAsync(string csvDir, List<string>? disabledTables = null)
     {
+        var stopwatch = Stopwatch.StartNew();
+
         var fkTargetError = ForeignKeyTargetValidator.Validate<TTableSet>();
         if (fkTargetError is not null)
         {
             throw fkTargetError;
         }
 
-        var tableSet = await BuildTablesAsync(csvDir, disabledTables);
+        var tableSet = await BuildTablesAsync(csvDir, disabledTables, logger);
 
         ReferenceValidator.Validate(tableSet);
         Validate(tableSet);
         current = tableSet;
+
+        stopwatch.Stop();
+        logger.LogInformation(
+            Messages.LoadAsyncCompleted,
+            stopwatch.ElapsedMilliseconds);
     }
 
     protected virtual void Validate(TTableSet tableSet)
     {
     }
 
-    private static async Task<TTableSet> BuildTablesAsync(string csvDir, List<string>? disabledTables)
+    private static async Task<TTableSet> BuildTablesAsync(
+        string csvDir,
+        List<string>? disabledTables,
+        ILogger logger)
     {
         var ctor = typeof(TTableSet).GetConstructors().Single();
         var parameters = ctor.GetParameters();
         var recordCache = new ConcurrentDictionary<RecordCacheKey, Lazy<Task<object>>>();
 
         var tasks = parameters
-            .Select(p => CreateTableAsync(p, csvDir, disabledTables, recordCache))
+            .Select(p => CreateTableAsync(p, csvDir, disabledTables, recordCache, logger))
             .ToArray();
 
         try
@@ -71,7 +83,8 @@ public abstract class StaticDataManager<TTableSet>
         ParameterInfo param,
         string csvDir,
         List<string>? disabledTables,
-        ConcurrentDictionary<RecordCacheKey, Lazy<Task<object>>> recordCache)
+        ConcurrentDictionary<RecordCacheKey, Lazy<Task<object>>> recordCache,
+        ILogger logger)
     {
         var tableType = param.ParameterType;
         if (!IsStaticDataTable(tableType))
@@ -87,6 +100,8 @@ public abstract class StaticDataManager<TTableSet>
         {
             return null;
         }
+
+        var stopwatch = Stopwatch.StartNew();
 
         var recordType = ExtractRecordType(tableType);
         var csvPath = ResolveCsvPath(csvDir, recordType);
@@ -109,6 +124,13 @@ public abstract class StaticDataManager<TTableSet>
         }
 
         table.Validate();
+
+        stopwatch.Stop();
+        logger.LogTrace(
+            Messages.LoadedTable,
+            param.Name,
+            stopwatch.ElapsedMilliseconds);
+
         return table;
     }
 

--- a/Sdp/Resources/Messages.Designer.cs
+++ b/Sdp/Resources/Messages.Designer.cs
@@ -84,6 +84,12 @@ internal static class Messages
     internal static string KeyPropertyNotFound
         => ResourceManager.GetString("KeyPropertyNotFound", Culture)!;
 
+    internal static string LoadedTable
+        => ResourceManager.GetString("LoadedTable", Culture)!;
+
+    internal static string LoadAsyncCompleted
+        => ResourceManager.GetString("LoadAsyncCompleted", Culture)!;
+
     internal static class Composite
     {
         internal static CompositeFormat InvalidTableParameter => CompositeFormat.Parse(Messages.InvalidTableParameter);

--- a/Sdp/Resources/Messages.ko.resx
+++ b/Sdp/Resources/Messages.ko.resx
@@ -66,4 +66,10 @@
   <data name="KeyPropertyNotFound" xml:space="preserve">
     <value>타입 '{1}'에서 '{0}' 프로퍼티를 찾을 수 없습니다.</value>
   </data>
+  <data name="LoadedTable" xml:space="preserve">
+    <value>테이블 {Name} 로드 완료 ({ElapsedMs}ms)</value>
+  </data>
+  <data name="LoadAsyncCompleted" xml:space="preserve">
+    <value>LoadAsync 완료 ({ElapsedMs}ms)</value>
+  </data>
 </root>

--- a/Sdp/Resources/Messages.resx
+++ b/Sdp/Resources/Messages.resx
@@ -66,4 +66,10 @@
   <data name="KeyPropertyNotFound" xml:space="preserve">
     <value>Property '{0}' not found on type '{1}'.</value>
   </data>
+  <data name="LoadedTable" xml:space="preserve">
+    <value>Loaded table {Name} in {ElapsedMs} ms</value>
+  </data>
+  <data name="LoadAsyncCompleted" xml:space="preserve">
+    <value>LoadAsync completed in {ElapsedMs} ms</value>
+  </data>
 </root>

--- a/Sdp/Sdp.csproj
+++ b/Sdp/Sdp.csproj
@@ -24,6 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UnitTest/AttributeValidatorTests/DateTimeFormatAttributeRuleTests.cs
+++ b/UnitTest/AttributeValidatorTests/DateTimeFormatAttributeRuleTests.cs
@@ -21,12 +21,12 @@ public class DateTimeFormatAttributeRuleTests(ITestOutputHelper testOutputHelper
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                         DateTime Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                       DateTime Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -47,11 +47,11 @@ public class DateTimeFormatAttributeRuleTests(ITestOutputHelper testOutputHelper
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         DateTime Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       DateTime Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -72,12 +72,12 @@ public class DateTimeFormatAttributeRuleTests(ITestOutputHelper testOutputHelper
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                         int Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                       int Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);

--- a/UnitTest/AttributeValidatorTests/FkSfkConflictAttributeRuleTests.cs
+++ b/UnitTest/AttributeValidatorTests/FkSfkConflictAttributeRuleTests.cs
@@ -21,13 +21,13 @@ public class FkSfkConflictAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         int Id,
-                         [ForeignKey("Other", "Id")]
-                         int Reference,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       int Id,
+                       [ForeignKey("Other", "Id")]
+                       int Reference,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -48,13 +48,13 @@ public class FkSfkConflictAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         int Id,
-                         [SwitchForeignKey("Id", "1", "Other", "Id")]
-                         int Reference,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       int Id,
+                       [SwitchForeignKey("Id", "1", "Other", "Id")]
+                       int Reference,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -75,14 +75,14 @@ public class FkSfkConflictAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         int Id,
-                         [ForeignKey("Other", "Id")]
-                         [SwitchForeignKey("Id", "1", "Other", "Id")]
-                         int Reference,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       int Id,
+                       [ForeignKey("Other", "Id")]
+                       [SwitchForeignKey("Id", "1", "Other", "Id")]
+                       int Reference,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);

--- a/UnitTest/AttributeValidatorTests/LengthAttributeRuleTests.cs
+++ b/UnitTest/AttributeValidatorTests/LengthAttributeRuleTests.cs
@@ -21,12 +21,12 @@ public class LengthAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)]
-                         ImmutableArray<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)]
+                       ImmutableArray<int> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -47,12 +47,12 @@ public class LengthAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)]
-                         FrozenSet<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)]
+                       FrozenSet<int> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -73,11 +73,11 @@ public class LengthAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         ImmutableArray<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       ImmutableArray<int> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);

--- a/UnitTest/AttributeValidatorTests/NullStringAttributeRuleTests.cs
+++ b/UnitTest/AttributeValidatorTests/NullStringAttributeRuleTests.cs
@@ -21,12 +21,12 @@ public class NullStringAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("-")]
-                         int? Property
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("-")]
+                       int? Property
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -47,13 +47,13 @@ public class NullStringAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("-")]
-                         [Length(3)]
-                         ImmutableArray<int?> Property
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("-")]
+                       [Length(3)]
+                       ImmutableArray<int?> Property
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -74,13 +74,13 @@ public class NullStringAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("-")]
-                         [Length(3)]
-                         FrozenSet<int?> Property
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("-")]
+                       [Length(3)]
+                       FrozenSet<int?> Property
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -101,11 +101,11 @@ public class NullStringAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         int? Property
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       int? Property
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -126,11 +126,11 @@ public class NullStringAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         ImmutableArray<int?> Property
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       ImmutableArray<int?> Property
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -151,11 +151,11 @@ public class NullStringAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         FrozenSet<int?> Property
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       FrozenSet<int?> Property
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -176,17 +176,17 @@ public class NullStringAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     public sealed record ValueRecord(
-                         [Key]
-                         int Id,
-                         string? Name
-                     );
+                   public sealed record ValueRecord(
+                       [Key]
+                       int Id,
+                       string? Name
+                   );
 
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         FrozenDictionary<int, ValueRecord> Property
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       FrozenDictionary<int, ValueRecord> Property
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -207,18 +207,18 @@ public class NullStringAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         FrozenDictionary<int, MyRecord.ValueRecord> Property
-                     )
-                     {
-                         public sealed record ValueRecord(
-                             [Key]
-                             int Id,
-                             string? Name
-                         );
-                     }
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       FrozenDictionary<int, MyRecord.ValueRecord> Property
+                   )
+                   {
+                       public sealed record ValueRecord(
+                           [Key]
+                           int Id,
+                           string? Name
+                       );
+                   }
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -239,12 +239,12 @@ public class NullStringAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("-")]
-                         int Property
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("-")]
+                       int Property
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -265,12 +265,12 @@ public class NullStringAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("-")]
-                         ImmutableArray<int> Property
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("-")]
+                       ImmutableArray<int> Property
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -291,12 +291,12 @@ public class NullStringAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("-")]
-                         FrozenSet<int> Property
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("-")]
+                       FrozenSet<int> Property
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -317,18 +317,18 @@ public class NullStringAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     public sealed record ValueRecord(
-                         [Key]
-                         int Id,
-                         string Name
-                     );
+                   public sealed record ValueRecord(
+                       [Key]
+                       int Id,
+                       string Name
+                   );
 
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("-")]
-                         FrozenDictionary<int, ValueRecord> Property
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("-")]
+                       FrozenDictionary<int, ValueRecord> Property
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -349,19 +349,19 @@ public class NullStringAttributeRuleTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("-")]
-                         FrozenDictionary<int, MyRecord.ValueRecord> Property
-                     )
-                     {
-                         public sealed record ValueRecord(
-                             [Key]
-                             int Id,
-                             string Name
-                         );
-                     }
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("-")]
+                       FrozenDictionary<int, MyRecord.ValueRecord> Property
+                   )
+                   {
+                       public sealed record ValueRecord(
+                           [Key]
+                           int Id,
+                           string Name
+                       );
+                   }
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);

--- a/UnitTest/AttributeValidatorTests/RegularExpressionAttributeRuleTests.cs
+++ b/UnitTest/AttributeValidatorTests/RegularExpressionAttributeRuleTests.cs
@@ -21,12 +21,12 @@ public class RegularExpressionAttributeRuleTests(ITestOutputHelper testOutputHel
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [RegularExpression(@"^[\w\.-]+@[\w\.-]+\.\w+$")]
-                         string EmailAddress,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [RegularExpression(@"^[\w\.-]+@[\w\.-]+\.\w+$")]
+                       string EmailAddress,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -47,12 +47,12 @@ public class RegularExpressionAttributeRuleTests(ITestOutputHelper testOutputHel
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [RegularExpression(@"^[\w\.-]+@[\w\.-]+\.\w+$")]
-                         int Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [RegularExpression(@"^[\w\.-]+@[\w\.-]+\.\w+$")]
+                       int Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);

--- a/UnitTest/AttributeValidatorTests/SingleColumnCollectionAttributeRuleTests.cs
+++ b/UnitTest/AttributeValidatorTests/SingleColumnCollectionAttributeRuleTests.cs
@@ -21,12 +21,12 @@ public class SingleColumnCollectionAttributeRuleTests(ITestOutputHelper testOutp
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(",")]
-                         ImmutableArray<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(",")]
+                       ImmutableArray<int> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -47,12 +47,12 @@ public class SingleColumnCollectionAttributeRuleTests(ITestOutputHelper testOutp
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(",")]
-                         FrozenSet<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(",")]
+                       FrozenSet<int> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -73,12 +73,12 @@ public class SingleColumnCollectionAttributeRuleTests(ITestOutputHelper testOutp
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(",")]
-                         int Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(",")]
+                       int Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);

--- a/UnitTest/AttributeValidatorTests/TimeSpanFormatAttributeRuleTests.cs
+++ b/UnitTest/AttributeValidatorTests/TimeSpanFormatAttributeRuleTests.cs
@@ -21,12 +21,12 @@ public class TimeSpanFormatAttributeRuleTests(ITestOutputHelper testOutputHelper
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [TimeSpanFormat("c")]
-                         TimeSpan Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [TimeSpanFormat("c")]
+                       TimeSpan Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -47,11 +47,11 @@ public class TimeSpanFormatAttributeRuleTests(ITestOutputHelper testOutputHelper
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         TimeSpan Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       TimeSpan Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -72,12 +72,12 @@ public class TimeSpanFormatAttributeRuleTests(ITestOutputHelper testOutputHelper
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [TimeSpanFormat("c")]
-                         int Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [TimeSpanFormat("c")]
+                       int Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);

--- a/UnitTest/CsvLoaderTests/CsvLoaderTests.cs
+++ b/UnitTest/CsvLoaderTests/CsvLoaderTests.cs
@@ -10,11 +10,11 @@ public class CsvLoaderTests
     public void Parse_WithValidCsv_ReturnsImmutableList()
     {
         var csv = """
-            Id,Name,Score
-            1,Alice,95.5
-            2,Bob,87.3
-            3,Charlie,92.1
-            """;
+                  Id,Name,Score
+                  1,Alice,95.5
+                  2,Bob,87.3
+                  3,Charlie,92.1
+                  """;
 
         var result = CsvLoader.Parse<SimpleRecord>(csv);
 
@@ -57,11 +57,11 @@ public class CsvLoaderTests
     public void Parse_WithBlankLines_SkipsBlankLines()
     {
         var csv = """
-            Id,Name,Score
-            1,Alice,95.5
+                  Id,Name,Score
+                  1,Alice,95.5
 
-            2,Bob,87.3
-            """;
+                  2,Bob,87.3
+                  """;
 
         var result = CsvLoader.Parse<SimpleRecord>(csv);
 
@@ -74,9 +74,9 @@ public class CsvLoaderTests
     public void Parse_ResultIsImmutable()
     {
         var csv = """
-            Id,Name,Score
-            1,Alice,95.5
-            """;
+                  Id,Name,Score
+                  1,Alice,95.5
+                  """;
 
         var result = CsvLoader.Parse<SimpleRecord>(csv);
 
@@ -90,10 +90,10 @@ public class CsvLoaderTests
         try
         {
             var csv = """
-                Id,Name,Score
-                1,Alice,95.5
-                2,Bob,87.3
-                """;
+                      Id,Name,Score
+                      1,Alice,95.5
+                      2,Bob,87.3
+                      """;
             await File.WriteAllTextAsync(tempFile, csv);
 
             var result = await CsvLoader.LoadAsync<SimpleRecord>(tempFile);
@@ -115,10 +115,10 @@ public class CsvLoaderTests
         try
         {
             var csv = """
-                Id,Name,Score
-                1,Alice,95.5
-                2,Bob,87.3
-                """;
+                      Id,Name,Score
+                      1,Alice,95.5
+                      2,Bob,87.3
+                      """;
             await File.WriteAllTextAsync(tempFile, csv);
 
             var result = await CsvLoader.LoadAsync<SimpleRecord>(tempFile);
@@ -137,10 +137,10 @@ public class CsvLoaderTests
     public void Parse_WithQuotedFieldContainingComma_ParsesCorrectly()
     {
         var csv = """
-            Id,Name,Score
-            1,"Smith, John",95.5
-            2,"Doe, Jane",87.3
-            """;
+                  Id,Name,Score
+                  1,"Smith, John",95.5
+                  2,"Doe, Jane",87.3
+                  """;
 
         var result = CsvLoader.Parse<SimpleRecord>(csv);
 

--- a/UnitTest/ForeignKeyTests/FkTargetSingleColumnCollectionValidationTests.cs
+++ b/UnitTest/ForeignKeyTests/FkTargetSingleColumnCollectionValidationTests.cs
@@ -1,12 +1,14 @@
 using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
 using Sdp.Attributes;
 using Sdp.Manager;
 using Sdp.Table;
 using UnitTest.Utility;
+using Xunit.Abstractions;
 
 namespace UnitTest.ForeignKeyTests;
 
-public class FkTargetSingleColumnCollectionValidationTests
+public class FkTargetSingleColumnCollectionValidationTests(ITestOutputHelper testOutputHelper)
 {
     private enum TagKind
     {
@@ -56,14 +58,16 @@ public class FkTargetSingleColumnCollectionValidationTests
     private sealed class SfkConsumerTable(ImmutableList<SfkConsumer> records)
         : StaticDataTable<SfkConsumerTable, SfkConsumer>(records);
 
-    private sealed class FkStaticData : StaticDataManager<FkStaticData.TableSet>
+    private sealed class FkStaticData(ILogger logger)
+        : StaticDataManager<FkStaticData.TableSet>(logger)
     {
         public sealed record TableSet(
             TagBundleTable? TagBundle,
             FkConsumerTable? FkConsumer);
     }
 
-    private sealed class SfkStaticData : StaticDataManager<SfkStaticData.TableSet>
+    private sealed class SfkStaticData(ILogger logger)
+        : StaticDataManager<SfkStaticData.TableSet>(logger)
     {
         public sealed record TableSet(
             TagBundleTable? TagBundle,
@@ -77,11 +81,18 @@ public class FkTargetSingleColumnCollectionValidationTests
         dir.Write("TagBundle.Sheet1.csv", TagBundleCsv);
         dir.Write("FkConsumer.Sheet1.csv", FkConsumerCsv);
 
-        var staticData = new FkStaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<FkTargetSingleColumnCollectionValidationTests>() is not TestOutputLogger<FkTargetSingleColumnCollectionValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new FkStaticData(logger);
 
         var ex = await Assert.ThrowsAsync<AggregateException>(() => staticData.LoadAsync(dir.Path));
 
         Assert.Contains(ex.InnerExceptions, e => e.Message.Contains("Tags") && e.Message.Contains("TagBundle"));
+        Assert.Empty(logger.Logs);
     }
 
     [Fact]
@@ -91,10 +102,17 @@ public class FkTargetSingleColumnCollectionValidationTests
         dir.Write("TagBundle.Sheet1.csv", TagBundleCsv);
         dir.Write("SfkConsumer.Sheet1.csv", SfkConsumerCsv);
 
-        var staticData = new SfkStaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<FkTargetSingleColumnCollectionValidationTests>() is not TestOutputLogger<FkTargetSingleColumnCollectionValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new SfkStaticData(logger);
 
         var ex = await Assert.ThrowsAsync<AggregateException>(() => staticData.LoadAsync(dir.Path));
 
         Assert.Contains(ex.InnerExceptions, e => e.Message.Contains("Tags") && e.Message.Contains("TagBundle"));
+        Assert.Empty(logger.Logs);
     }
 }

--- a/UnitTest/ForeignKeyTests/ForeignKeyValidationTests.cs
+++ b/UnitTest/ForeignKeyTests/ForeignKeyValidationTests.cs
@@ -1,12 +1,14 @@
 using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
 using Sdp.Attributes;
 using Sdp.Manager;
 using Sdp.Table;
 using UnitTest.Utility;
+using Xunit.Abstractions;
 
 namespace UnitTest.ForeignKeyTests;
 
-public class ForeignKeyValidationTests
+public class ForeignKeyValidationTests(ITestOutputHelper testOutputHelper)
 {
     private const string SchoolCsv =
         """
@@ -111,7 +113,8 @@ public class ForeignKeyValidationTests
         public Student Get(int id) => byId.Get(id);
     }
 
-    private sealed class StaticData : StaticDataManager<StaticData.TableSet>
+    private sealed class StaticData(ILogger logger)
+        : StaticDataManager<StaticData.TableSet>(logger)
     {
         public sealed record TableSet(
             SchoolTable? School,
@@ -131,12 +134,19 @@ public class ForeignKeyValidationTests
         dir.Write("Teacher.Sheet1.csv", TeacherCsv);
         dir.Write("Student.Sheet1.csv", StudentCsv);
 
-        var staticData = new StaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<ForeignKeyValidationTests>() is not TestOutputLogger<ForeignKeyValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new StaticData(logger);
         await staticData.LoadAsync(dir.Path);
 
         Assert.Equal(5, staticData.SchoolTable.Records.Count);
         Assert.Equal(3, staticData.TeacherTable.Records.Count);
         Assert.Equal(5, staticData.StudentTable.Records.Count);
+        Assert.Empty(logger.Logs);
     }
 
     [Fact]
@@ -147,7 +157,13 @@ public class ForeignKeyValidationTests
         dir.Write("Teacher.Sheet1.csv", TeacherCsv);
         dir.Write("Student.Sheet1.csv", StudentCsv);
 
-        var staticData = new StaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<ForeignKeyValidationTests>() is not TestOutputLogger<ForeignKeyValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new StaticData(logger);
         await staticData.LoadAsync(dir.Path);
 
         var student = staticData.StudentTable.Get(4);
@@ -155,6 +171,7 @@ public class ForeignKeyValidationTests
 
         var school = staticData.SchoolTable.Get(student.SchoolId);
         Assert.Equal("고려대학교", school.Name);
+        Assert.Empty(logger.Logs);
     }
 
     [Fact]
@@ -165,7 +182,13 @@ public class ForeignKeyValidationTests
         dir.Write("Teacher.Sheet1.csv", TeacherCsv);
         dir.Write("Student.Sheet1.csv", StudentCsv);
 
-        var staticData = new StaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<ForeignKeyValidationTests>() is not TestOutputLogger<ForeignKeyValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new StaticData(logger);
         await staticData.LoadAsync(dir.Path);
 
         var student = staticData.StudentTable.Get(3);
@@ -173,6 +196,7 @@ public class ForeignKeyValidationTests
 
         var teacher = staticData.TeacherTable.Get(student.TeacherId);
         Assert.Equal("이영희", teacher.Name);
+        Assert.Empty(logger.Logs);
     }
 
     [Fact]
@@ -183,12 +207,19 @@ public class ForeignKeyValidationTests
         dir.Write("Teacher.Sheet1.csv", ErrorTeacherCsv);
         dir.Write("Student.Sheet1.csv", StudentCsv);
 
-        var staticData = new StaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<ForeignKeyValidationTests>() is not TestOutputLogger<ForeignKeyValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new StaticData(logger);
 
         var ex = await Assert.ThrowsAsync<AggregateException>(() => staticData.LoadAsync(dir.Path));
 
         Assert.Single(ex.InnerExceptions);
         Assert.Contains("Error대학교", ex.InnerExceptions[0].Message);
+        Assert.Empty(logger.Logs);
     }
 
     [Fact]
@@ -199,11 +230,18 @@ public class ForeignKeyValidationTests
         dir.Write("Teacher.Sheet1.csv", TeacherCsv);
         dir.Write("Student.Sheet1.csv", ErrorStudentCsv);
 
-        var staticData = new StaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<ForeignKeyValidationTests>() is not TestOutputLogger<ForeignKeyValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new StaticData(logger);
 
         var ex = await Assert.ThrowsAsync<AggregateException>(() => staticData.LoadAsync(dir.Path));
 
         Assert.Single(ex.InnerExceptions);
         Assert.Contains("999", ex.InnerExceptions[0].Message);
+        Assert.Empty(logger.Logs);
     }
 }

--- a/UnitTest/ForeignKeyTests/MultipleForeignKeyValidationTests.cs
+++ b/UnitTest/ForeignKeyTests/MultipleForeignKeyValidationTests.cs
@@ -1,12 +1,14 @@
 using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
 using Sdp.Attributes;
 using Sdp.Manager;
 using Sdp.Table;
 using UnitTest.Utility;
+using Xunit.Abstractions;
 
 namespace UnitTest.ForeignKeyTests;
 
-public class MultipleForeignKeyValidationTests
+public class MultipleForeignKeyValidationTests(ITestOutputHelper testOutputHelper)
 {
     private const string SchoolCsv =
         """
@@ -68,7 +70,8 @@ public class MultipleForeignKeyValidationTests
     private sealed class ScholarshipTable(ImmutableList<Scholarship> records)
         : StaticDataTable<ScholarshipTable, Scholarship>(records);
 
-    private sealed class StaticData : StaticDataManager<StaticData.TableSet>
+    private sealed class StaticData(ILogger logger)
+        : StaticDataManager<StaticData.TableSet>(logger)
     {
         public sealed record TableSet(
             SchoolTable? School,
@@ -88,10 +91,17 @@ public class MultipleForeignKeyValidationTests
         dir.Write("Teacher.Sheet1.csv", TeacherCsv);
         dir.Write("Scholarship.Sheet1.csv", ScholarshipCsv);
 
-        var staticData = new StaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<MultipleForeignKeyValidationTests>() is not TestOutputLogger<MultipleForeignKeyValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new StaticData(logger);
         await staticData.LoadAsync(dir.Path);
 
         Assert.Equal(2, staticData.ScholarshipTable.Records.Count);
+        Assert.Empty(logger.Logs);
     }
 
     [Fact]
@@ -102,11 +112,18 @@ public class MultipleForeignKeyValidationTests
         dir.Write("Teacher.Sheet1.csv", TeacherCsv);
         dir.Write("Scholarship.Sheet1.csv", ErrorScholarshipCsv);
 
-        var staticData = new StaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<MultipleForeignKeyValidationTests>() is not TestOutputLogger<MultipleForeignKeyValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new StaticData(logger);
 
         var ex = await Assert.ThrowsAsync<AggregateException>(() => staticData.LoadAsync(dir.Path));
 
         Assert.Single(ex.InnerExceptions);
         Assert.Contains("99", ex.InnerExceptions[0].Message);
+        Assert.Empty(logger.Logs);
     }
 }

--- a/UnitTest/ForeignKeyTests/SwitchForeignKeyNonKeyValidationTests.cs
+++ b/UnitTest/ForeignKeyTests/SwitchForeignKeyNonKeyValidationTests.cs
@@ -1,12 +1,14 @@
 using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
 using Sdp.Attributes;
 using Sdp.Manager;
 using Sdp.Table;
 using UnitTest.Utility;
+using Xunit.Abstractions;
 
 namespace UnitTest.ForeignKeyTests;
 
-public class SwitchForeignKeyNonKeyValidationTests
+public class SwitchForeignKeyNonKeyValidationTests(ITestOutputHelper testOutputHelper)
 {
     private enum Department
     {
@@ -65,7 +67,8 @@ public class SwitchForeignKeyNonKeyValidationTests
     private sealed class DesignerTable(ImmutableList<Designer> records)
         : StaticDataTable<DesignerTable, Designer>(records);
 
-    private sealed class StaticData : StaticDataManager<StaticData.TableSet>
+    private sealed class StaticData(ILogger logger)
+        : StaticDataManager<StaticData.TableSet>(logger)
     {
         public sealed record TableSet(
             StaffTable? Staff,
@@ -83,10 +86,17 @@ public class SwitchForeignKeyNonKeyValidationTests
         dir.Write("Engineer.Sheet1.csv", EngineerCsv);
         dir.Write("Designer.Sheet1.csv", DesignerCsv);
 
-        var staticData = new StaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<SwitchForeignKeyNonKeyValidationTests>() is not TestOutputLogger<SwitchForeignKeyNonKeyValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new StaticData(logger);
         await staticData.LoadAsync(dir.Path);
 
         Assert.Equal(2, staticData.StaffTable.Records.Count);
+        Assert.Empty(logger.Logs);
     }
 
     [Fact]
@@ -97,11 +107,18 @@ public class SwitchForeignKeyNonKeyValidationTests
         dir.Write("Engineer.Sheet1.csv", EngineerCsv);
         dir.Write("Designer.Sheet1.csv", DesignerCsv);
 
-        var staticData = new StaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<SwitchForeignKeyNonKeyValidationTests>() is not TestOutputLogger<SwitchForeignKeyNonKeyValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new StaticData(logger);
 
         var ex = await Assert.ThrowsAsync<AggregateException>(() => staticData.LoadAsync(dir.Path));
 
         Assert.Single(ex.InnerExceptions);
         Assert.Contains("UnknownDesigner", ex.InnerExceptions[0].Message);
+        Assert.Empty(logger.Logs);
     }
 }

--- a/UnitTest/ForeignKeyTests/SwitchForeignKeyValidationTests.cs
+++ b/UnitTest/ForeignKeyTests/SwitchForeignKeyValidationTests.cs
@@ -1,12 +1,14 @@
 using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
 using Sdp.Attributes;
 using Sdp.Manager;
 using Sdp.Table;
 using UnitTest.Utility;
+using Xunit.Abstractions;
 
 namespace UnitTest.ForeignKeyTests;
 
-public class SwitchForeignKeyValidationTests
+public class SwitchForeignKeyValidationTests(ITestOutputHelper testOutputHelper)
 {
     private enum RewardType
     {
@@ -97,7 +99,8 @@ public class SwitchForeignKeyValidationTests
     private sealed class CurrencyTable(ImmutableList<Currency> records)
         : StaticDataTable<CurrencyTable, Currency>(records);
 
-    private sealed class StaticData : StaticDataManager<StaticData.TableSet>
+    private sealed class StaticData(ILogger logger)
+        : StaticDataManager<StaticData.TableSet>(logger)
     {
         public sealed record TableSet(
             QuestTable? Quest,
@@ -122,10 +125,17 @@ public class SwitchForeignKeyValidationTests
         dir.Write("Quest.Sheet1.csv", ValidQuestCsv);
         WriteFixedCsvs(dir);
 
-        var staticData = new StaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<SwitchForeignKeyValidationTests>() is not TestOutputLogger<SwitchForeignKeyValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new StaticData(logger);
         await staticData.LoadAsync(dir.Path);
 
         Assert.Equal(3, staticData.QuestTable.Records.Count);
+        Assert.Empty(logger.Logs);
     }
 
     [Fact]
@@ -135,12 +145,19 @@ public class SwitchForeignKeyValidationTests
         dir.Write("Quest.Sheet1.csv", ErrorQuestCsv);
         WriteFixedCsvs(dir);
 
-        var staticData = new StaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<SwitchForeignKeyValidationTests>() is not TestOutputLogger<SwitchForeignKeyValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new StaticData(logger);
 
         var ex = await Assert.ThrowsAsync<AggregateException>(() => staticData.LoadAsync(dir.Path));
 
         Assert.Single(ex.InnerExceptions);
         Assert.Contains("999", ex.InnerExceptions[0].Message);
+        Assert.Empty(logger.Logs);
     }
 
     [Fact]
@@ -150,11 +167,18 @@ public class SwitchForeignKeyValidationTests
         dir.Write("Quest.Sheet1.csv", NoConditionQuestCsv);
         WriteFixedCsvs(dir);
 
-        var staticData = new StaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<SwitchForeignKeyValidationTests>() is not TestOutputLogger<SwitchForeignKeyValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new StaticData(logger);
         await staticData.LoadAsync(dir.Path);
 
         var quest = Assert.Single(staticData.QuestTable.Records);
         Assert.Equal(RewardType.None, quest.RewardType);
+        Assert.Empty(logger.Logs);
     }
 
     [Fact]
@@ -166,17 +190,24 @@ public class SwitchForeignKeyValidationTests
         dir.Write("Quest.Sheet1.csv", CrossTableQuestCsv);
         WriteFixedCsvs(dir);
 
-        var staticData = new StaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<SwitchForeignKeyValidationTests>() is not TestOutputLogger<SwitchForeignKeyValidationTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new StaticData(logger);
 
         var ex = await Assert.ThrowsAsync<AggregateException>(() => staticData.LoadAsync(dir.Path));
 
         Assert.Single(ex.InnerExceptions);
         Assert.Contains("5", ex.InnerExceptions[0].Message);
         Assert.Contains("when RewardType=Item", ex.InnerExceptions[0].Message);
+        Assert.Empty(logger.Logs);
     }
 }
 
-public class SwitchForeignKeyConfigurationErrorTests
+public class SwitchForeignKeyConfigurationErrorTests(ITestOutputHelper testOutputHelper)
 {
     // conditionColumnName이 Record에 없는 경우
     private const string BadConditionQuestCsv =
@@ -206,7 +237,8 @@ public class SwitchForeignKeyConfigurationErrorTests
     private sealed class TargetTable(ImmutableList<Target> records)
         : StaticDataTable<TargetTable, Target>(records);
 
-    private sealed class ConditionColumnStaticData : StaticDataManager<ConditionColumnStaticData.TableSet>
+    private sealed class ConditionColumnStaticData(ILogger logger)
+        : StaticDataManager<ConditionColumnStaticData.TableSet>(logger)
     {
         public sealed record TableSet(BadConditionQuestTable? Quest, TargetTable? Target);
     }
@@ -233,7 +265,8 @@ public class SwitchForeignKeyConfigurationErrorTests
     private sealed class BadTargetQuestTable(ImmutableList<BadTargetQuest> records)
         : StaticDataTable<BadTargetQuestTable, BadTargetQuest>(records);
 
-    private sealed class TargetTableStaticData : StaticDataManager<TargetTableStaticData.TableSet>
+    private sealed class TargetTableStaticData(ILogger logger)
+        : StaticDataManager<TargetTableStaticData.TableSet>(logger)
     {
         public sealed record TableSet(BadTargetQuestTable? Quest);
     }
@@ -245,12 +278,19 @@ public class SwitchForeignKeyConfigurationErrorTests
         dir.Write("BadConditionQuest.Sheet1.csv", BadConditionQuestCsv);
         dir.Write("Target.Sheet1.csv", TargetCsv);
 
-        var staticData = new ConditionColumnStaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<SwitchForeignKeyConfigurationErrorTests>() is not TestOutputLogger<SwitchForeignKeyConfigurationErrorTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new ConditionColumnStaticData(logger);
 
         var ex = await Assert.ThrowsAsync<AggregateException>(() => staticData.LoadAsync(dir.Path));
 
         Assert.Single(ex.InnerExceptions);
         Assert.Contains("NonExistentColumn", ex.InnerExceptions[0].Message);
+        Assert.Empty(logger.Logs);
     }
 
     [Fact]
@@ -259,11 +299,18 @@ public class SwitchForeignKeyConfigurationErrorTests
         using var dir = new CsvTestDirectory();
         dir.Write("BadTargetQuest.Sheet1.csv", BadTargetQuestCsv);
 
-        var staticData = new TargetTableStaticData();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<SwitchForeignKeyConfigurationErrorTests>() is not TestOutputLogger<SwitchForeignKeyConfigurationErrorTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var staticData = new TargetTableStaticData(logger);
 
         var ex = await Assert.ThrowsAsync<AggregateException>(() => staticData.LoadAsync(dir.Path));
 
         Assert.Single(ex.InnerExceptions);
         Assert.Contains("NonExistentTable", ex.InnerExceptions[0].Message);
+        Assert.Empty(logger.Logs);
     }
 }

--- a/UnitTest/NotSupportedPropertyCompatibilityTests/NullableEmptySpaceCompatibilityTests.cs
+++ b/UnitTest/NotSupportedPropertyCompatibilityTests/NullableEmptySpaceCompatibilityTests.cs
@@ -21,13 +21,13 @@ public class NullableEmptySpaceCompatibilityTests(ITestOutputHelper testOutputHe
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("-")]
-                         [Length(5)]
-                         FrozenSet<int?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("-")]
+                       [Length(5)]
+                       FrozenSet<int?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 

--- a/UnitTest/NotSupportedPropertyCompatibilityTests/PrimitiveTypeTests.cs
+++ b/UnitTest/NotSupportedPropertyCompatibilityTests/PrimitiveTypeTests.cs
@@ -25,11 +25,11 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
         foreach (var recordSchema in catalogs.RecordSchemaCatalog.StaticDataRecordSchemata)
@@ -66,11 +66,11 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
         foreach (var recordSchema in catalogs.RecordSchemaCatalog.StaticDataRecordSchemata)

--- a/UnitTest/NotSupportedPropertySchemaTests/CollectionPropertySchemaTests/ListTypeTests.cs
+++ b/UnitTest/NotSupportedPropertySchemaTests/CollectionPropertySchemaTests/ListTypeTests.cs
@@ -21,11 +21,11 @@ public class ListTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         ImmutableArray<{collection}<int>> Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        ImmutableArray<{collection}<int>> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         Assert.Throws<NotSupportedException>(() => new RecordSchemaSet(loadResult, logger));
@@ -43,11 +43,11 @@ public class ListTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         List<Dictionary<int, string>> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       List<Dictionary<int, string>> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         Assert.Throws<NotSupportedException>(() => new RecordSchemaSet(loadResult, logger));

--- a/UnitTest/NotSupportedPropertySchemaTests/CollectionPropertySchemaTests/MapTypeTests.cs
+++ b/UnitTest/NotSupportedPropertySchemaTests/CollectionPropertySchemaTests/MapTypeTests.cs
@@ -22,11 +22,11 @@ public class MapTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         Dictionary<int, {collection}<int>> Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        Dictionary<int, {collection}<int>> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         Assert.Throws<NotSupportedException>(() => new RecordSchemaSet(loadResult, logger));
@@ -44,11 +44,11 @@ public class MapTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         Dictionary<int, Dictionary<int, string>> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       Dictionary<int, Dictionary<int, string>> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         Assert.Throws<NotSupportedException>(() => new RecordSchemaSet(loadResult, logger));
@@ -80,11 +80,11 @@ public class MapTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)] FrozenDictionary<int, {value}> Property
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [Length(3)] FrozenDictionary<int, {value}> Property
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         Assert.Throws<NotSupportedException>(() => new RecordSchemaSet(loadResult, logger));

--- a/UnitTest/NotSupportedPropertySchemaTests/CollectionPropertySchemaTests/NotSupportedCollectionTests.cs
+++ b/UnitTest/NotSupportedPropertySchemaTests/CollectionPropertySchemaTests/NotSupportedCollectionTests.cs
@@ -34,11 +34,11 @@ public class NotSupportedCollectionTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         {collection}<int> Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        {collection}<int> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         Assert.Throws<NotSupportedException>(() => new RecordSchemaSet(loadResult, logger));

--- a/UnitTest/NotSupportedPropertySchemaTests/CollectionPropertySchemaTests/SetTypeTest.cs
+++ b/UnitTest/NotSupportedPropertySchemaTests/CollectionPropertySchemaTests/SetTypeTest.cs
@@ -21,11 +21,11 @@ public class SetTypeTest(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         HashSet<{collection}<int>> Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        HashSet<{collection}<int>> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         Assert.Throws<NotSupportedException>(() => new RecordSchemaSet(loadResult, logger));
@@ -43,11 +43,11 @@ public class SetTypeTest(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         HashSet<Dictionary<int, string>> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       HashSet<Dictionary<int, string>> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         Assert.Throws<NotSupportedException>(() => new RecordSchemaSet(loadResult, logger));

--- a/UnitTest/NotSupportedPropertySchemaTests/ObjectTypeTests.cs
+++ b/UnitTest/NotSupportedPropertySchemaTests/ObjectTypeTests.cs
@@ -19,11 +19,11 @@ public class ObjectTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         object Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       object Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         Assert.Throws<NotSupportedException>(() => new RecordSchemaSet(loadResult, logger));
@@ -41,16 +41,16 @@ public class ObjectTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         MyData Property,
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       MyData Property,
+                   );
 
-                     public sealed class MyData
-                     {
-                         public int Value { get; set; }
-                     }
-                     """;
+                   public sealed class MyData
+                   {
+                       public int Value { get; set; }
+                   }
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         Assert.Throws<NotSupportedException>(() => new RecordSchemaSet(loadResult, logger));

--- a/UnitTest/NotSupportedPropertySchemaTests/PrimitiveTypeTests.cs
+++ b/UnitTest/NotSupportedPropertySchemaTests/PrimitiveTypeTests.cs
@@ -21,11 +21,11 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        {type} Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         Assert.Throws<NotSupportedException>(() => new RecordSchemaSet(loadResult, logger));

--- a/UnitTest/PropertySchemaCompatibilityTests/CollectionPropertySchemaTests/ArrayTypeTests.cs
+++ b/UnitTest/PropertySchemaCompatibilityTests/CollectionPropertySchemaTests/ArrayTypeTests.cs
@@ -21,12 +21,12 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)]
-                         ImmutableArray<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)]
+                       ImmutableArray<int> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -62,14 +62,14 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     public enum MyEnum { A, B, C }
+                   public enum MyEnum { A, B, C }
 
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(2)]
-                         ImmutableArray<MyEnum> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(2)]
+                       ImmutableArray<MyEnum> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -103,13 +103,13 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                         [Length(2)]
-                         ImmutableArray<DateTime> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                       [Length(2)]
+                       ImmutableArray<DateTime> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -143,13 +143,13 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [TimeSpanFormat("c")]
-                         [Length(2)]
-                         ImmutableArray<TimeSpan> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [TimeSpanFormat("c")]
+                       [Length(2)]
+                       ImmutableArray<TimeSpan> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -183,12 +183,12 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         ImmutableArray<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       ImmutableArray<int> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -221,13 +221,13 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [Length(4)]
-                         ImmutableArray<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [Length(4)]
+                       ImmutableArray<int> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 

--- a/UnitTest/PropertySchemaCompatibilityTests/CollectionPropertySchemaTests/NullableTypes/ArrayTypeTests.cs
+++ b/UnitTest/PropertySchemaCompatibilityTests/CollectionPropertySchemaTests/NullableTypes/ArrayTypeTests.cs
@@ -21,11 +21,11 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)][NullString("-")] ImmutableArray<int?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)][NullString("-")] ImmutableArray<int?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -61,13 +61,13 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     public enum MyEnum { A, B, C }
+                   public enum MyEnum { A, B, C }
 
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)][NullString("-")] ImmutableArray<MyEnum?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)][NullString("-")] ImmutableArray<MyEnum?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -102,14 +102,14 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                         [NullString("-")]
-                         [Length(3)]
-                         ImmutableArray<DateTime?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                       [NullString("-")]
+                       [Length(3)]
+                       ImmutableArray<DateTime?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -144,14 +144,14 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [TimeSpanFormat("c")]
-                         [NullString("-")]
-                         [Length(2)]
-                         ImmutableArray<TimeSpan?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [TimeSpanFormat("c")]
+                       [NullString("-")]
+                       [Length(2)]
+                       ImmutableArray<TimeSpan?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -185,13 +185,13 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("")]
-                         [SingleColumnCollection(", ")]
-                         ImmutableArray<int?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("")]
+                       [SingleColumnCollection(", ")]
+                       ImmutableArray<int?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -224,15 +224,15 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     public enum MyEnum { A, B, C }
+                   public enum MyEnum { A, B, C }
 
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [NullString("")]
-                         ImmutableArray<MyEnum?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [NullString("")]
+                       ImmutableArray<MyEnum?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -265,14 +265,14 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [NullString("")]
-                         [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                         ImmutableArray<DateTime?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [NullString("")]
+                       [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                       ImmutableArray<DateTime?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -305,14 +305,14 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [TimeSpanFormat("c")]
-                         [NullString("")]
-                         ImmutableArray<TimeSpan?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [TimeSpanFormat("c")]
+                       [NullString("")]
+                       ImmutableArray<TimeSpan?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 

--- a/UnitTest/PropertySchemaCompatibilityTests/CollectionPropertySchemaTests/NullableTypes/SetTypeTests.cs
+++ b/UnitTest/PropertySchemaCompatibilityTests/CollectionPropertySchemaTests/NullableTypes/SetTypeTests.cs
@@ -21,13 +21,13 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("-")]
-                         [Length(4)]
-                         FrozenSet<int?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("-")]
+                       [Length(4)]
+                       FrozenSet<int?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -63,13 +63,13 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("-")]
-                         [Length(5)]
-                         FrozenSet<int?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("-")]
+                       [Length(5)]
+                       FrozenSet<int?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -107,15 +107,15 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     public enum MyEnum { A, B, C }
+                   public enum MyEnum { A, B, C }
 
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("-")]
-                         [Length(3)]
-                         FrozenSet<MyEnum?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("-")]
+                       [Length(3)]
+                       FrozenSet<MyEnum?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -150,14 +150,14 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                         [NullString("-")]
-                         [Length(3)]
-                         FrozenSet<DateTime?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                       [NullString("-")]
+                       [Length(3)]
+                       FrozenSet<DateTime?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -192,14 +192,14 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [TimeSpanFormat("c")]
-                         [NullString("-")]
-                         [Length(2)]
-                         FrozenSet<TimeSpan?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [TimeSpanFormat("c")]
+                       [NullString("-")]
+                       [Length(2)]
+                       FrozenSet<TimeSpan?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -233,13 +233,13 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("")]
-                         [SingleColumnCollection(", ")]
-                         FrozenSet<int?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [NullString("")]
+                       [SingleColumnCollection(", ")]
+                       FrozenSet<int?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -272,15 +272,15 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     public enum MyEnum { A, B, C }
+                   public enum MyEnum { A, B, C }
 
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [NullString("")]
-                         FrozenSet<MyEnum?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [NullString("")]
+                       FrozenSet<MyEnum?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -313,14 +313,14 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [NullString("")]
-                         [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                         FrozenSet<DateTime?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [NullString("")]
+                       [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                       FrozenSet<DateTime?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -353,14 +353,14 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [TimeSpanFormat("c")]
-                         [NullString("")]
-                         FrozenSet<TimeSpan?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [TimeSpanFormat("c")]
+                       [NullString("")]
+                       FrozenSet<TimeSpan?> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 

--- a/UnitTest/PropertySchemaCompatibilityTests/CollectionPropertySchemaTests/SetTypeTests.cs
+++ b/UnitTest/PropertySchemaCompatibilityTests/CollectionPropertySchemaTests/SetTypeTests.cs
@@ -21,12 +21,12 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(4)]
-                         FrozenSet<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(4)]
+                       FrozenSet<int> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -62,12 +62,12 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(4)]
-                         FrozenSet<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(4)]
+                       FrozenSet<int> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -104,14 +104,14 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     public enum MyEnum { A, a, C }
+                   public enum MyEnum { A, a, C }
 
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(2)]
-                         FrozenSet<MyEnum> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(2)]
+                       FrozenSet<MyEnum> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -145,14 +145,14 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     public enum MyEnum { A, B, C }
+                   public enum MyEnum { A, B, C }
 
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)]
-                         FrozenSet<MyEnum> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)]
+                       FrozenSet<MyEnum> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -188,13 +188,13 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                         [Length(2)]
-                         FrozenSet<DateTime> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                       [Length(2)]
+                       FrozenSet<DateTime> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -228,13 +228,13 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [TimeSpanFormat("c")]
-                         [Length(2)]
-                         FrozenSet<TimeSpan> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [TimeSpanFormat("c")]
+                       [Length(2)]
+                       FrozenSet<TimeSpan> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -268,12 +268,12 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         FrozenSet<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       FrozenSet<int> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -306,13 +306,13 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [Length(4)]
-                         FrozenSet<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [Length(4)]
+                       FrozenSet<int> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -345,12 +345,12 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         FrozenSet<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       FrozenSet<int> Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 

--- a/UnitTest/PropertySchemaCompatibilityTests/PrimitiveTypes/ErrorMessageTests.cs
+++ b/UnitTest/PropertySchemaCompatibilityTests/PrimitiveTypes/ErrorMessageTests.cs
@@ -35,11 +35,11 @@ public class ErrorMessageTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -78,12 +78,12 @@ public class ErrorMessageTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [RegularExpression("^[A-Z]{3}$")]
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [RegularExpression("^[A-Z]{3}$")]
+                        {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -167,12 +167,12 @@ public class ErrorMessageTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                        {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -211,12 +211,12 @@ public class ErrorMessageTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [TimeSpanFormat("c")]
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [TimeSpanFormat("c")]
+                        {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
 

--- a/UnitTest/PropertySchemaCompatibilityTests/PrimitiveTypes/NullableTypes/PrimitiveTypeTests.cs
+++ b/UnitTest/PropertySchemaCompatibilityTests/PrimitiveTypes/NullableTypes/PrimitiveTypeTests.cs
@@ -72,11 +72,11 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("")] {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [NullString("")] {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -160,11 +160,11 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("")] {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [NullString("")] {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -238,13 +238,13 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                         [NullString("")]
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                        [NullString("")]
+                        {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -278,13 +278,13 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [TimeSpanFormat("c")]
-                         [NullString("")]
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [TimeSpanFormat("c")]
+                        [NullString("")]
+                        {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
 

--- a/UnitTest/PropertySchemaCompatibilityTests/PrimitiveTypes/PrimitiveTypeTests.cs
+++ b/UnitTest/PropertySchemaCompatibilityTests/PrimitiveTypes/PrimitiveTypeTests.cs
@@ -72,11 +72,11 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
         var cells = new[]
@@ -159,11 +159,11 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
         var context = CompatibilityContext.CreateNoCollect(catalogs, [new CellData("A1", argument)]);
@@ -231,12 +231,12 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                        {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -270,12 +270,12 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [TimeSpanFormat("c")]
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [TimeSpanFormat("c")]
+                        {type} Property,
+                    );
+                    """;
 
         var catalogs = CreateCatalogs(code, logger);
 

--- a/UnitTest/PropertySchemaCompatibilityTests/PrimitiveTypes/RangeAttributeCompatibilityTests.cs
+++ b/UnitTest/PropertySchemaCompatibilityTests/PrimitiveTypes/RangeAttributeCompatibilityTests.cs
@@ -24,12 +24,12 @@ public class RangeAttributeCompatibilityTests(ITestOutputHelper testOutputHelper
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Range(1, 100)]
-                         int Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Range(1, 100)]
+                       int Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
         var cells = new[] { new CellData("A1", value) };
@@ -61,12 +61,12 @@ public class RangeAttributeCompatibilityTests(ITestOutputHelper testOutputHelper
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Range(1, 100)]
-                         int Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Range(1, 100)]
+                       int Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
         var cells = new[] { new CellData("A1", value) };
@@ -98,12 +98,12 @@ public class RangeAttributeCompatibilityTests(ITestOutputHelper testOutputHelper
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Range(0.5, 10.5)]
-                         double Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Range(0.5, 10.5)]
+                       double Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
         var cells = new[] { new CellData("A1", value) };
@@ -133,12 +133,12 @@ public class RangeAttributeCompatibilityTests(ITestOutputHelper testOutputHelper
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Range(0.5, 10.5)]
-                         double Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Range(0.5, 10.5)]
+                       double Property,
+                   );
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
         var cells = new[] { new CellData("A1", value) };

--- a/UnitTest/PropertySchemaCompatibilityTests/RecordTypes/RecordTypeTests.cs
+++ b/UnitTest/PropertySchemaCompatibilityTests/RecordTypes/RecordTypeTests.cs
@@ -21,14 +21,14 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         Identifier Id
-                     )
-                     {
-                        public record struct Identifier(int Value);
-                     }
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       Identifier Id
+                   )
+                   {
+                      public record struct Identifier(int Value);
+                   }
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -61,13 +61,13 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         MyData Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       MyData Data
+                   );
 
-                     public record struct MyData(int Key, string Value);
-                     """;
+                   public record struct MyData(int Key, string Value);
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -101,13 +101,13 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)] ImmutableArray<MyData> Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] ImmutableArray<MyData> Data
+                   );
 
-                     public record struct MyData(int Key, string Value);
-                     """;
+                   public record struct MyData(int Key, string Value);
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -145,13 +145,13 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)] FrozenSet<MyData> Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] FrozenSet<MyData> Data
+                   );
 
-                     public record struct MyData(int Key, string Value);
-                     """;
+                   public record struct MyData(int Key, string Value);
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -189,13 +189,13 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)] FrozenDictionary<int, MyData> Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] FrozenDictionary<int, MyData> Data
+                   );
 
-                     public record struct MyData([Key] int Id, string Value);
-                     """;
+                   public record struct MyData([Key] int Id, string Value);
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -233,18 +233,18 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)] FrozenDictionary<KeyData, MyData> Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] FrozenDictionary<KeyData, MyData> Data
+                   );
 
-                     public record struct KeyData(InnerKey Inner, int Key1)
-                     {
-                         public record struct InnerKey(int X, int Y);
-                     }
+                   public record struct KeyData(InnerKey Inner, int Key1)
+                   {
+                       public record struct InnerKey(int X, int Y);
+                   }
 
-                     public record struct MyData([Key] KeyData Key, string Value);
-                     """;
+                   public record struct MyData([Key] KeyData Key, string Value);
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -299,22 +299,22 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     public enum Grades
-                     {
-                         A,
-                         B,
-                         C,
-                         D,
-                         F,
-                     }
+                   public enum Grades
+                   {
+                       A,
+                       B,
+                       C,
+                       D,
+                       F,
+                   }
 
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)] ImmutableArray<NameScore> Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] ImmutableArray<NameScore> Data
+                   );
 
-                     public record struct NameScore(string Name, [Length(2)] ImmutableArray<Grades> Grade);
-                     """;
+                   public record struct NameScore(string Name, [Length(2)] ImmutableArray<Grades> Grade);
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -358,22 +358,22 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     public enum Grades
-                     {
-                         A,
-                         B,
-                         C,
-                         D,
-                         F,
-                     }
+                   public enum Grades
+                   {
+                       A,
+                       B,
+                       C,
+                       D,
+                       F,
+                   }
 
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)] FrozenSet<NameScore> Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] FrozenSet<NameScore> Data
+                   );
 
-                     public record struct NameScore(string Name, [Length(2)] ImmutableArray<Grades> Grade);
-                     """;
+                   public record struct NameScore(string Name, [Length(2)] ImmutableArray<Grades> Grade);
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 
@@ -416,22 +416,22 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     public enum Grades
-                     {
-                         A,
-                         B,
-                         C,
-                         D,
-                         F,
-                     }
+                   public enum Grades
+                   {
+                       A,
+                       B,
+                       C,
+                       D,
+                       F,
+                   }
 
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)] FrozenDictionary<string, NameScore> Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] FrozenDictionary<string, NameScore> Data
+                   );
 
-                     public record struct NameScore([Key] string Name, [Length(2)] ImmutableArray<Grades> Grade);
-                     """;
+                   public record struct NameScore([Key] string Name, [Length(2)] ImmutableArray<Grades> Grade);
+                   """;
 
         var catalogs = CreateCatalogs(code, logger);
 

--- a/UnitTest/PropertySchemaTests/CollectionPropertySchemaTests/ArrayTypeTests.cs
+++ b/UnitTest/PropertySchemaTests/CollectionPropertySchemaTests/ArrayTypeTests.cs
@@ -34,11 +34,11 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                   [StaticDataRecord("Test", "TestSheet")]
-                   public sealed record MyRecord(
-                       [Length(3)] ImmutableArray<{type}> Property,
-                   );
-                   """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [Length(3)] ImmutableArray<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -74,13 +74,13 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("")]
-                         [Length(3)]
-                         ImmutableArray<{type}> Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [NullString("")]
+                        [Length(3)]
+                        ImmutableArray<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -132,13 +132,13 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                   [StaticDataRecord("Test", "TestSheet")]
-                   public sealed record MyRecord(
-                       [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                       [Length(3)]
-                       ImmutableArray<{type}> Property,
-                   );
-                   """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                        [Length(3)]
+                        ImmutableArray<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -161,14 +161,14 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                         [NullString("")]
-                         [Length(3)]
-                         ImmutableArray<{type}> Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                        [NullString("")]
+                        [Length(3)]
+                        ImmutableArray<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -191,13 +191,13 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                   [StaticDataRecord("Test", "TestSheet")]
-                   public sealed record MyRecord(
-                       [TimeSpanFormat("c")]
-                       [Length(3)]
-                       ImmutableArray<{type}> Property,
-                   );
-                   """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [TimeSpanFormat("c")]
+                        [Length(3)]
+                        ImmutableArray<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -220,14 +220,14 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [TimeSpanFormat("c")]
-                         [NullString("")]
-                         [Length(3)]
-                         ImmutableArray<{type}> Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [TimeSpanFormat("c")]
+                        [NullString("")]
+                        [Length(3)]
+                        ImmutableArray<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -249,12 +249,12 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         ImmutableArray<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       ImmutableArray<int> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -276,13 +276,13 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [Length(3)]
-                         ImmutableArray<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [Length(3)]
+                       ImmutableArray<int> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 

--- a/UnitTest/PropertySchemaTests/CollectionPropertySchemaTests/NullableTypes/ArrayTypeTests.cs
+++ b/UnitTest/PropertySchemaTests/CollectionPropertySchemaTests/NullableTypes/ArrayTypeTests.cs
@@ -34,11 +34,11 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                   [StaticDataRecord("Test", "TestSheet")]
-                   public sealed record MyRecord(
-                       [Length(3)][NullString("")] ImmutableArray<{type}> Property,
-                   );
-                   """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [Length(3)][NullString("")] ImmutableArray<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -90,14 +90,14 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                   [StaticDataRecord("Test", "TestSheet")]
-                   public sealed record MyRecord(
-                       [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                       [NullString("")]
-                       [Length(3)]
-                       ImmutableArray<{type}> Property,
-                   );
-                   """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                        [NullString("")]
+                        [Length(3)]
+                        ImmutableArray<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -120,14 +120,14 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                   [StaticDataRecord("Test", "TestSheet")]
-                   public sealed record MyRecord(
-                       [TimeSpanFormat("c")]
-                       [NullString("")]
-                       [Length(3)]
-                       ImmutableArray<{type}> Property,
-                   );
-                   """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [TimeSpanFormat("c")]
+                        [NullString("")]
+                        [Length(3)]
+                        ImmutableArray<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -149,13 +149,13 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [NullString("")]
-                         ImmutableArray<int?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [NullString("")]
+                       ImmutableArray<int?> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -177,14 +177,14 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [Length(3)]
-                         [NullString("")]
-                         ImmutableArray<int?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [Length(3)]
+                       [NullString("")]
+                       ImmutableArray<int?> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 

--- a/UnitTest/PropertySchemaTests/CollectionPropertySchemaTests/NullableTypes/SetTypeTests.cs
+++ b/UnitTest/PropertySchemaTests/CollectionPropertySchemaTests/NullableTypes/SetTypeTests.cs
@@ -34,11 +34,11 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)][NullString("")] FrozenSet<{type}> Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [Length(3)][NullString("")] FrozenSet<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -90,14 +90,14 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                   [StaticDataRecord("Test", "TestSheet")]
-                   public sealed record MyRecord(
-                       [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                       [NullString("")]
-                       [Length(3)]
-                       FrozenSet<{type}> Property,
-                   );
-                   """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                        [NullString("")]
+                        [Length(3)]
+                        FrozenSet<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -120,14 +120,14 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                   [StaticDataRecord("Test", "TestSheet")]
-                   public sealed record MyRecord(
-                       [TimeSpanFormat("c")]
-                       [NullString("")]
-                       [Length(3)]
-                       FrozenSet<{type}> Property,
-                   );
-                   """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [TimeSpanFormat("c")]
+                        [NullString("")]
+                        [Length(3)]
+                        FrozenSet<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -149,13 +149,13 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [NullString("")]
-                         FrozenSet<int?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [NullString("")]
+                       FrozenSet<int?> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -177,14 +177,14 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [Length(3)]
-                         [NullString("")]
-                         FrozenSet<int?> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [Length(3)]
+                       [NullString("")]
+                       FrozenSet<int?> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 

--- a/UnitTest/PropertySchemaTests/CollectionPropertySchemaTests/SetTypeTests.cs
+++ b/UnitTest/PropertySchemaTests/CollectionPropertySchemaTests/SetTypeTests.cs
@@ -34,11 +34,11 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                   [StaticDataRecord("Test", "TestSheet")]
-                   public sealed record MyRecord(
-                       [Length(3)] FrozenSet<{type}> Property,
-                   );
-                   """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [Length(3)] FrozenSet<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -90,13 +90,13 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                   [StaticDataRecord("Test", "TestSheet")]
-                   public sealed record MyRecord(
-                       [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                       [Length(3)]
-                       FrozenSet<{type}> Property,
-                   );
-                   """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                        [Length(3)]
+                        FrozenSet<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -119,13 +119,13 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                   [StaticDataRecord("Test", "TestSheet")]
-                   public sealed record MyRecord(
-                       [TimeSpanFormat("c")]
-                       [Length(3)]
-                       FrozenSet<{type}> Property,
-                   );
-                   """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [TimeSpanFormat("c")]
+                        [Length(3)]
+                        FrozenSet<{type}> Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -147,12 +147,12 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         FrozenSet<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       FrozenSet<int> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -174,13 +174,13 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [SingleColumnCollection(", ")]
-                         [Length(3)]
-                         FrozenSet<int> Property,
-                     );
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(", ")]
+                       [Length(3)]
+                       FrozenSet<int> Property,
+                   );
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 

--- a/UnitTest/PropertySchemaTests/PrimitiveTypes/NullableTypes/PrimitiveTypeTests.cs
+++ b/UnitTest/PropertySchemaTests/PrimitiveTypes/NullableTypes/PrimitiveTypeTests.cs
@@ -34,11 +34,11 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("")] {type}? Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [NullString("")] {type}? Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -74,11 +74,11 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [NullString("")] {type}? Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [NullString("")] {type}? Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -130,13 +130,13 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
-                         [NullString("")]
-                         {type}? Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [DateTimeFormat("yyyy-MM-dd HH:mm:ss.fff")]
+                        [NullString("")]
+                        {type}? Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -159,13 +159,13 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [TimeSpanFormat("c")]
-                         [NullString("")]
-                         {type}? Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [TimeSpanFormat("c")]
+                        [NullString("")]
+                        {type}? Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 

--- a/UnitTest/PropertySchemaTests/PrimitiveTypes/PrimitiveTypeTests.cs
+++ b/UnitTest/PropertySchemaTests/PrimitiveTypes/PrimitiveTypeTests.cs
@@ -34,11 +34,11 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        {type} Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -74,11 +74,11 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        {type} Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -158,12 +158,12 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = $"""
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [TimeSpanFormat("c")]
-                         {type} Property,
-                     );
-                     """;
+                    [StaticDataRecord("Test", "TestSheet")]
+                    public sealed record MyRecord(
+                        [TimeSpanFormat("c")]
+                        {type} Property,
+                    );
+                    """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 

--- a/UnitTest/PropertySchemaTests/RecordTypeSchemaTests/RecordTypeTests.cs
+++ b/UnitTest/PropertySchemaTests/RecordTypeSchemaTests/RecordTypeTests.cs
@@ -20,14 +20,14 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         Identifier Id
-                     )
-                     {
-                        public record struct Identifier(int Value);
-                     }
-                     """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       Identifier Id
+                   )
+                   {
+                      public record struct Identifier(int Value);
+                   }
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -49,13 +49,13 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         MyData Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       MyData Data
+                   );
 
-                     public record struct MyData(int Value);
-                     """;
+                   public record struct MyData(int Value);
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -77,13 +77,13 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)] ImmutableArray<MyData> Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] ImmutableArray<MyData> Data
+                   );
 
-                     public record struct MyData(int Value);
-                     """;
+                   public record struct MyData(int Value);
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -105,13 +105,13 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)] FrozenSet<MyData> Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] FrozenSet<MyData> Data
+                   );
 
-                     public record struct MyData(int Value);
-                     """;
+                   public record struct MyData(int Value);
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -133,13 +133,13 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)] FrozenDictionary<int, MyData> Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] FrozenDictionary<int, MyData> Data
+                   );
 
-                     public record struct MyData([Key] int Id, string Value);
-                     """;
+                   public record struct MyData([Key] int Id, string Value);
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -161,14 +161,14 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)] FrozenDictionary<KeyData, MyData> Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] FrozenDictionary<KeyData, MyData> Data
+                   );
 
-                     public record struct KeyData(int Key1, string Key2);
-                     public record struct MyData([Key] KeyData Key, string Value);
-                     """;
+                   public record struct KeyData(int Key1, string Key2);
+                   public record struct MyData([Key] KeyData Key, string Value);
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 
@@ -190,18 +190,18 @@ public class RecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-                     [StaticDataRecord("Test", "TestSheet")]
-                     public sealed record MyRecord(
-                         [Length(3)] FrozenDictionary<KeyData, MyData> Data
-                     );
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] FrozenDictionary<KeyData, MyData> Data
+                   );
 
-                     public record struct KeyData(InnerKey Inner, int Key1)
-                     {
-                         public record struct InnerKey(int X, int Y);
-                     }
+                   public record struct KeyData(InnerKey Inner, int Key1)
+                   {
+                       public record struct InnerKey(int X, int Y);
+                   }
 
-                     public record struct MyData([Key] KeyData Key, string Value);
-                     """;
+                   public record struct MyData([Key] KeyData Key, string Value);
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
 

--- a/UnitTest/RecordFlattenerTests/ArrayTypeTests.cs
+++ b/UnitTest/RecordFlattenerTests/ArrayTypeTests.cs
@@ -18,11 +18,11 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [Length(3)] ImmutableArray<int> Scores
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] ImmutableArray<int> Scores
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -49,11 +49,11 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [ColumnName("Score")][Length(3)] ImmutableArray<int> Scores
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [ColumnName("Score")][Length(3)] ImmutableArray<int> Scores
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -80,11 +80,11 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [SingleColumnCollection(",")][Length(3)] ImmutableArray<int> Scores
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(",")][Length(3)] ImmutableArray<int> Scores
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -109,13 +109,13 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                string Name,
-                [Length(2)] ImmutableArray<int> Scores,
-                [Length(3)] ImmutableArray<string> Tags
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       string Name,
+                       [Length(2)] ImmutableArray<int> Scores,
+                       [Length(3)] ImmutableArray<string> Tags
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -145,19 +145,19 @@ public class ArrayTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            public sealed record Character(
-                [ColumnName("Name")] string Nickname,
-                Character.Stat Info
-            )
-            {
-                public sealed record Stat(int Hp, int Mp);
-            }
+                   public sealed record Character(
+                       [ColumnName("Name")] string Nickname,
+                       Character.Stat Info
+                   )
+                   {
+                       public sealed record Stat(int Hp, int Mp);
+                   }
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [Length(2), ColumnName("Hero")] ImmutableArray<Character> Party
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(2), ColumnName("Hero")] ImmutableArray<Character> Party
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 

--- a/UnitTest/RecordFlattenerTests/MapPrimitiveTypeTests.cs
+++ b/UnitTest/RecordFlattenerTests/MapPrimitiveTypeTests.cs
@@ -18,17 +18,17 @@ public class MapPrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            public sealed record UserInfo(
-                [Key] string Name,
-                int Age,
-                string Email
-            );
+                   public sealed record UserInfo(
+                       [Key] string Name,
+                       int Age,
+                       string Email
+                   );
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [Length(2)] FrozenDictionary<string, UserInfo> Users
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(2)] FrozenDictionary<string, UserInfo> Users
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -58,22 +58,22 @@ public class MapPrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            public sealed record AddressInfo(
-                string City,
-                string ZipCode
-            );
+                   public sealed record AddressInfo(
+                       string City,
+                       string ZipCode
+                   );
 
-            public sealed record UserInfo(
-                [Key] string Name,
-                int Age,
-                AddressInfo Address
-            );
+                   public sealed record UserInfo(
+                       [Key] string Name,
+                       int Age,
+                       AddressInfo Address
+                   );
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [Length(2)] FrozenDictionary<string, UserInfo> Users
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(2)] FrozenDictionary<string, UserInfo> Users
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -106,16 +106,16 @@ public class MapPrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            public sealed record UserInfo(
-                [Key][ColumnName("UserName")] string Name,
-                [ColumnName("UserAge")] int Age
-            );
+                   public sealed record UserInfo(
+                       [Key][ColumnName("UserName")] string Name,
+                       [ColumnName("UserAge")] int Age
+                   );
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [ColumnName("UserData")][Length(2)] FrozenDictionary<string, UserInfo> Users
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [ColumnName("UserData")][Length(2)] FrozenDictionary<string, UserInfo> Users
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 

--- a/UnitTest/RecordFlattenerTests/MapRecordTypeTests.cs
+++ b/UnitTest/RecordFlattenerTests/MapRecordTypeTests.cs
@@ -18,22 +18,22 @@ public class MapRecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            public sealed record ItemKey(
-                int Id,
-                string Type
-            );
+                   public sealed record ItemKey(
+                       int Id,
+                       string Type
+                   );
 
-            public sealed record ItemStatus(
-                [Key] ItemKey Key,
-                int Level,
-                int Power
-            );
+                   public sealed record ItemStatus(
+                       [Key] ItemKey Key,
+                       int Level,
+                       int Power
+                   );
 
-            [StaticDataRecord("GameData", "Items")]
-            public sealed record ItemCollection(
-                [Length(2)] FrozenDictionary<ItemKey, ItemStatus> Inventory
-            );
-            """;
+                   [StaticDataRecord("GameData", "Items")]
+                   public sealed record ItemCollection(
+                       [Length(2)] FrozenDictionary<ItemKey, ItemStatus> Inventory
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -65,27 +65,27 @@ public class MapRecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            public sealed record ItemKey(
-                int Id,
-                string Type
-            );
+                   public sealed record ItemKey(
+                       int Id,
+                       string Type
+                   );
 
-            public sealed record StatInfo(
-                int Attack,
-                int Defense
-            );
+                   public sealed record StatInfo(
+                       int Attack,
+                       int Defense
+                   );
 
-            public sealed record ItemStatus(
-                [Key] ItemKey Key,
-                int Level,
-                StatInfo Stats
-            );
+                   public sealed record ItemStatus(
+                       [Key] ItemKey Key,
+                       int Level,
+                       StatInfo Stats
+                   );
 
-            [StaticDataRecord("GameData", "Items")]
-            public sealed record ItemCollection(
-                [Length(2)] FrozenDictionary<ItemKey, ItemStatus> Inventory
-            );
-            """;
+                   [StaticDataRecord("GameData", "Items")]
+                   public sealed record ItemCollection(
+                       [Length(2)] FrozenDictionary<ItemKey, ItemStatus> Inventory
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -119,25 +119,25 @@ public class MapRecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            public sealed record ItemKey(
-                int Id,
-                string Type
-            );
+                   public sealed record ItemKey(
+                       int Id,
+                       string Type
+                   );
 
-            public sealed record ItemStatus(
-                [Key] ItemKey Key,
-                int Level,
-                ItemStatus.StatInfo Stats
-            )
-            {
-                public sealed record StatInfo(int Attack, int Defense);
-            }
+                   public sealed record ItemStatus(
+                       [Key] ItemKey Key,
+                       int Level,
+                       ItemStatus.StatInfo Stats
+                   )
+                   {
+                       public sealed record StatInfo(int Attack, int Defense);
+                   }
 
-            [StaticDataRecord("GameData", "Items")]
-            public sealed record ItemCollection(
-                [Length(2)] FrozenDictionary<ItemKey, ItemStatus> Inventory
-            );
-            """;
+                   [StaticDataRecord("GameData", "Items")]
+                   public sealed record ItemCollection(
+                       [Length(2)] FrozenDictionary<ItemKey, ItemStatus> Inventory
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -171,21 +171,21 @@ public class MapRecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            public sealed record KeyRecord(
-                int Id,
-                [Length(3)] ImmutableArray<string> Tags
-            );
+                   public sealed record KeyRecord(
+                       int Id,
+                       [Length(3)] ImmutableArray<string> Tags
+                   );
 
-            public sealed record ValueRecord(
-                [Key] KeyRecord Name,
-                int Score
-            );
+                   public sealed record ValueRecord(
+                       [Key] KeyRecord Name,
+                       int Score
+                   );
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [Length(2)] FrozenDictionary<KeyRecord, ValueRecord> Data
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(2)] FrozenDictionary<KeyRecord, ValueRecord> Data
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -219,21 +219,21 @@ public class MapRecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            public sealed record KeyRecord(
-                [ColumnName("ID")] int Id,
-                [Length(3), ColumnName("Tag")] ImmutableArray<string> Tags
-            );
+                   public sealed record KeyRecord(
+                       [ColumnName("ID")] int Id,
+                       [Length(3), ColumnName("Tag")] ImmutableArray<string> Tags
+                   );
 
-            public sealed record ValueRecord(
-                [Key] KeyRecord Name,
-                [ColumnName("Point")] int Score
-            );
+                   public sealed record ValueRecord(
+                       [Key] KeyRecord Name,
+                       [ColumnName("Point")] int Score
+                   );
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [Length(2), ColumnName("Inven")] FrozenDictionary<KeyRecord, ValueRecord> Data
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(2), ColumnName("Inven")] FrozenDictionary<KeyRecord, ValueRecord> Data
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -267,28 +267,28 @@ public class MapRecordTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            public sealed record UserKey(
-                [ColumnName("UID")] int UserId,
-                [Length(2), ColumnName("TR")] ImmutableArray<UserKey.TraitInfo> Traits
-            )
-            {
-                public sealed record TraitInfo([ColumnName("Tid")] int TraitId, int Level);
-            }
+                   public sealed record UserKey(
+                       [ColumnName("UID")] int UserId,
+                       [Length(2), ColumnName("TR")] ImmutableArray<UserKey.TraitInfo> Traits
+                   )
+                   {
+                       public sealed record TraitInfo([ColumnName("Tid")] int TraitId, int Level);
+                   }
 
-            public sealed record UserProfile(
-                [Key] UserKey Key,
-                [Length(2), ColumnName("SK")] FrozenSet<UserProfile.SkillInfo> Skills,
-                int Rank
-            )
-            {
-                public sealed record SkillInfo([ColumnName("Sid")] string SkillId, bool IsActive);
-            }
+                   public sealed record UserProfile(
+                       [Key] UserKey Key,
+                       [Length(2), ColumnName("SK")] FrozenSet<UserProfile.SkillInfo> Skills,
+                       int Rank
+                   )
+                   {
+                       public sealed record SkillInfo([ColumnName("Sid")] string SkillId, bool IsActive);
+                   }
 
-            [StaticDataRecord("GameData", "Users")]
-            public sealed record UserDataCatalog(
-                [Length(2), ColumnName("Player")] FrozenDictionary<UserKey, UserProfile> Data
-            );
-            """;
+                   [StaticDataRecord("GameData", "Users")]
+                   public sealed record UserDataCatalog(
+                       [Length(2), ColumnName("Player")] FrozenDictionary<UserKey, UserProfile> Data
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 

--- a/UnitTest/RecordFlattenerTests/PrimitiveTypeTests.cs
+++ b/UnitTest/RecordFlattenerTests/PrimitiveTypeTests.cs
@@ -18,11 +18,11 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                int Id
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       int Id
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -47,14 +47,14 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                int Id,
-                string Name,
-                double Score,
-                bool IsActive
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       int Id,
+                       string Name,
+                       double Score,
+                       bool IsActive
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -82,12 +82,12 @@ public class PrimitiveTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [ColumnName("UserId")] int Id,
-                [ColumnName("UserName")] string Name
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [ColumnName("UserId")] int Id,
+                       [ColumnName("UserName")] string Name
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 

--- a/UnitTest/RecordFlattenerTests/SetTypeTests.cs
+++ b/UnitTest/RecordFlattenerTests/SetTypeTests.cs
@@ -18,11 +18,11 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [Length(3)] FrozenSet<int> Ids
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(3)] FrozenSet<int> Ids
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -49,11 +49,11 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [ColumnName("UserId")][Length(2)] FrozenSet<int> Ids
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [ColumnName("UserId")][Length(2)] FrozenSet<int> Ids
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -79,11 +79,11 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [SingleColumnCollection(",")][Length(3)] FrozenSet<string> Tags
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [SingleColumnCollection(",")][Length(3)] FrozenSet<string> Tags
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -108,13 +108,13 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                string Name,
-                [Length(2)] FrozenSet<int> Ids,
-                [Length(3)] FrozenSet<string> Tags
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       string Name,
+                       [Length(2)] FrozenSet<int> Ids,
+                       [Length(3)] FrozenSet<string> Tags
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 
@@ -144,16 +144,16 @@ public class SetTypeTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            public sealed record ItemInfo(
-                [ColumnName("ID")] int ItemId,
-                int Count
-            );
+                   public sealed record ItemInfo(
+                       [ColumnName("ID")] int ItemId,
+                       int Count
+                   );
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyRecord(
-                [Length(2), ColumnName("Inven")] FrozenSet<ItemInfo> Items
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       [Length(2), ColumnName("Inven")] FrozenSet<ItemInfo> Items
+                   );
+                   """;
 
         var parseResult = SimpleCordParser.Parse(code, logger);
 

--- a/UnitTest/RecordScanTests/RecordNameTests.cs
+++ b/UnitTest/RecordScanTests/RecordNameTests.cs
@@ -17,10 +17,10 @@ public class RecordNameTests(ITestOutputHelper testOutputHelper)
     {
         // language=C#
         var code = """
-            namespace Docs.TestRecord;
+                   namespace Docs.TestRecord;
 
-            public sealed record SimpleRecord(int Id, string Name);
-            """;
+                   public sealed record SimpleRecord(int Id, string Name);
+                   """;
 
         var syntaxTree = CSharpSyntaxTree.ParseText(code);
         var compilation = CSharpCompilation.Create("Test", [syntaxTree]);
@@ -48,13 +48,13 @@ public class RecordNameTests(ITestOutputHelper testOutputHelper)
     {
         // language=C#
         var code = """
-            namespace Docs.TestRecord;
+                   namespace Docs.TestRecord;
 
-            public sealed record ParentRecord(int Id, ParentRecord.ChildRecord Child)
-            {
-                public sealed record ChildRecord(string Name);
-            }
-            """;
+                   public sealed record ParentRecord(int Id, ParentRecord.ChildRecord Child)
+                   {
+                       public sealed record ChildRecord(string Name);
+                   }
+                   """;
 
         var syntaxTree = CSharpSyntaxTree.ParseText(code);
         var compilation = CSharpCompilation.Create("Test", [syntaxTree]);
@@ -87,18 +87,18 @@ public class RecordNameTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            using System.Collections.Frozen;
-            using Sdp.Attributes;
+                   using System.Collections.Frozen;
+                   using Sdp.Attributes;
 
-            namespace Docs.TestRecord;
+                   namespace Docs.TestRecord;
 
-            public sealed record ItemData([Key] int ItemId, string ItemName);
+                   public sealed record ItemData([Key] int ItemId, string ItemName);
 
-            [StaticDataRecord("Excel2", "DictionarySheet")]
-            public sealed record DictionarySheet(
-                int Id,
-                [Length(2)] FrozenDictionary<int, ItemData> Items);
-            """;
+                   [StaticDataRecord("Excel2", "DictionarySheet")]
+                   public sealed record DictionarySheet(
+                       int Id,
+                       [Length(2)] FrozenDictionary<int, ItemData> Items);
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
@@ -122,19 +122,19 @@ public class RecordNameTests(ITestOutputHelper testOutputHelper)
 
         // language=C#
         var code = """
-            using System.Collections.Frozen;
-            using Sdp.Attributes;
+                   using System.Collections.Frozen;
+                   using Sdp.Attributes;
 
-            namespace Docs.TestRecord;
+                   namespace Docs.TestRecord;
 
-            [StaticDataRecord("Excel2", "DictionarySheet")]
-            public sealed record DictionarySheet(
-                int Id,
-                [Length(2)] FrozenDictionary<int, DictionarySheet.ItemData> Items)
-            {
-                public sealed record ItemData([Key] int ItemId, string ItemName);
-            }
-            """;
+                   [StaticDataRecord("Excel2", "DictionarySheet")]
+                   public sealed record DictionarySheet(
+                       int Id,
+                       [Length(2)] FrozenDictionary<int, DictionarySheet.ItemData> Items)
+                   {
+                       public sealed record ItemData([Key] int ItemId, string ItemName);
+                   }
+                   """;
 
         var loadResult = RecordSchemaLoader.OnLoad(code, logger);
         var recordSchemaSet = new RecordSchemaSet(loadResult, logger);

--- a/UnitTest/RecordScanTests/RecordSchemaParameterFlattenerTest.cs
+++ b/UnitTest/RecordScanTests/RecordSchemaParameterFlattenerTest.cs
@@ -12,19 +12,19 @@ public class RecordSchemaParameterFlattenerTest(ITestOutputHelper testOutputHelp
     {
         // language=C#
         var code = """
-            public sealed record Subject(
-                string Name,
-                [Length(2)] ImmutableArray<int> QuarterScore
-            );
+                   public sealed record Subject(
+                       string Name,
+                       [Length(2)] ImmutableArray<int> QuarterScore
+                   );
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyClass(
-                string Name,
-                [Length(3)] ImmutableArray<Subject> SubjectA,
-                int Age,
-                [Length(4)] ImmutableArray<Subject> SubjectB
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyClass(
+                       string Name,
+                       [Length(3)] ImmutableArray<Subject> SubjectA,
+                       int Age,
+                       [Length(4)] ImmutableArray<Subject> SubjectB
+                   );
+                   """;
 
         var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
         if (factory.CreateLogger<RecordSchemaParameterFlattenerTest>() is not TestOutputLogger<RecordSchemaParameterFlattenerTest> logger)
@@ -53,19 +53,19 @@ public class RecordSchemaParameterFlattenerTest(ITestOutputHelper testOutputHelp
     {
         // language=C#
         var code = """
-            public sealed record Subject(
-                string Name,
-                [SingleColumnCollection(", ")][Length(4)] ImmutableArray<int> QuarterScore
-            );
+                   public sealed record Subject(
+                       string Name,
+                       [SingleColumnCollection(", ")][Length(4)] ImmutableArray<int> QuarterScore
+                   );
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyClass(
-                string Name,
-                [Length(3)] ImmutableArray<Subject> SubjectA,
-                int Age,
-                [Length(4)] ImmutableArray<Subject> SubjectB
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyClass(
+                       string Name,
+                       [Length(3)] ImmutableArray<Subject> SubjectA,
+                       int Age,
+                       [Length(4)] ImmutableArray<Subject> SubjectB
+                   );
+                   """;
 
         var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
         if (factory.CreateLogger<RecordSchemaParameterFlattenerTest>() is not TestOutputLogger<RecordSchemaParameterFlattenerTest> logger)
@@ -94,19 +94,19 @@ public class RecordSchemaParameterFlattenerTest(ITestOutputHelper testOutputHelp
     {
         // language=C#
         var code = """
-            public sealed record Subject(
-                string Name,
-                [SingleColumnCollection(", ")][ColumnName("QuarterScores")][Length(4)] ImmutableArray<int> QuarterScore
-            );
+                   public sealed record Subject(
+                       string Name,
+                       [SingleColumnCollection(", ")][ColumnName("QuarterScores")][Length(4)] ImmutableArray<int> QuarterScore
+                   );
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyClass(
-                string Name,
-                [Length(3)] ImmutableArray<Subject> SubjectA,
-                int Age,
-                [Length(4)] ImmutableArray<Subject> SubjectB
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyClass(
+                       string Name,
+                       [Length(3)] ImmutableArray<Subject> SubjectA,
+                       int Age,
+                       [Length(4)] ImmutableArray<Subject> SubjectB
+                   );
+                   """;
 
         var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
         if (factory.CreateLogger<RecordSchemaParameterFlattenerTest>() is not TestOutputLogger<RecordSchemaParameterFlattenerTest> logger)
@@ -135,19 +135,19 @@ public class RecordSchemaParameterFlattenerTest(ITestOutputHelper testOutputHelp
     {
         // language=C#
         var code = """
-            public sealed record Subject(
-                [ColumnName("Bar")] string Name,
-                [ColumnName("Scores")][Length(2)] ImmutableArray<int> QuarterScore
-            );
+                   public sealed record Subject(
+                       [ColumnName("Bar")] string Name,
+                       [ColumnName("Scores")][Length(2)] ImmutableArray<int> QuarterScore
+                   );
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyClass(
-                string Name,
-                [Length(3)][ColumnName("SubjectF")] ImmutableArray<Subject> SubjectA,
-                int Age,
-                [Length(4)]ImmutableArray<Subject> SubjectB,
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyClass(
+                       string Name,
+                       [Length(3)][ColumnName("SubjectF")] ImmutableArray<Subject> SubjectA,
+                       int Age,
+                       [Length(4)]ImmutableArray<Subject> SubjectB,
+                   );
+                   """;
 
         var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
         if (factory.CreateLogger<RecordSchemaParameterFlattenerTest>() is not TestOutputLogger<RecordSchemaParameterFlattenerTest> logger)
@@ -176,14 +176,14 @@ public class RecordSchemaParameterFlattenerTest(ITestOutputHelper testOutputHelp
     {
         // language=C#
         var code = """
-            public sealed record MyRecord([Key] int Id, int Value);
+                   public sealed record MyRecord([Key] int Id, int Value);
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyStaticData(
-                string Name,
-                [Length(3)] FrozenDictionary<int, MyRecord> MyDictionary,
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyStaticData(
+                       string Name,
+                       [Length(3)] FrozenDictionary<int, MyRecord> MyDictionary,
+                   );
+                   """;
 
         var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
         if (factory.CreateLogger<RecordSchemaParameterFlattenerTest>() is not TestOutputLogger<RecordSchemaParameterFlattenerTest> logger)
@@ -212,14 +212,14 @@ public class RecordSchemaParameterFlattenerTest(ITestOutputHelper testOutputHelp
     {
         // language=C#
         var code = """
-            public sealed record Human(string Name, int Age);
-            public sealed record MyRecord([Key] Human Human, int Value);
+                   public sealed record Human(string Name, int Age);
+                   public sealed record MyRecord([Key] Human Human, int Value);
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record MyStaticData(
-                [Length(3)] FrozenDictionary<Human, MyRecord> MyDictionary,
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyStaticData(
+                       [Length(3)] FrozenDictionary<Human, MyRecord> MyDictionary,
+                   );
+                   """;
 
         var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
         if (factory.CreateLogger<RecordSchemaParameterFlattenerTest>() is not TestOutputLogger<RecordSchemaParameterFlattenerTest> logger)
@@ -248,28 +248,28 @@ public class RecordSchemaParameterFlattenerTest(ITestOutputHelper testOutputHelp
     {
         // language=C#
         var code = """
-            public sealed record Address(string Street, string City);
-            public sealed record ContactInfo(string PhoneNumber, string Email);
-            public sealed record Project(string ProjectName, [Length(6)] ImmutableArray<string> TeamMembers, double Budget);
-            public sealed record Department(string DepartmentName, [Length(2)] ImmutableArray<Project> Projects);
+                   public sealed record Address(string Street, string City);
+                   public sealed record ContactInfo(string PhoneNumber, string Email);
+                   public sealed record Project(string ProjectName, [Length(6)] ImmutableArray<string> TeamMembers, double Budget);
+                   public sealed record Department(string DepartmentName, [Length(2)] ImmutableArray<Project> Projects);
 
-            public sealed record Employee(
-                string FullName,
-                int Age,
-                Address HomeAddress,
-                ContactInfo Contact,
-                string Position,
-                [Length(3)] ImmutableArray<Department> Departments
-            );
+                   public sealed record Employee(
+                       string FullName,
+                       int Age,
+                       Address HomeAddress,
+                       ContactInfo Contact,
+                       string Position,
+                       [Length(3)] ImmutableArray<Department> Departments
+                   );
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record Company(
-                string CompanyName,
-                Address HeadquartersAddress,
-                [Length(5)] FrozenSet<Employee> Employees,
-                [Length(3)] ImmutableArray<Department> CoreDepartments
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record Company(
+                       string CompanyName,
+                       Address HeadquartersAddress,
+                       [Length(5)] FrozenSet<Employee> Employees,
+                       [Length(3)] ImmutableArray<Department> CoreDepartments
+                   );
+                   """;
 
         var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
         if (factory.CreateLogger<RecordSchemaParameterFlattenerTest>() is not TestOutputLogger<RecordSchemaParameterFlattenerTest> logger)
@@ -298,16 +298,16 @@ public class RecordSchemaParameterFlattenerTest(ITestOutputHelper testOutputHelp
     {
         // language=C#
         var code = """
-            public sealed record SchoolId(int Value);
-            public sealed record TeacherId(int Value);
+                   public sealed record SchoolId(int Value);
+                   public sealed record TeacherId(int Value);
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record School(
-                SchoolId Id,
-                string Name,
-                TeacherId MainTeacher
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record School(
+                       SchoolId Id,
+                       string Name,
+                       TeacherId MainTeacher
+                   );
+                   """;
 
         var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
         if (factory.CreateLogger<RecordSchemaParameterFlattenerTest>() is not TestOutputLogger<RecordSchemaParameterFlattenerTest> logger)
@@ -340,16 +340,16 @@ public class RecordSchemaParameterFlattenerTest(ITestOutputHelper testOutputHelp
     {
         // language=C#
         var code = """
-            public sealed record EntityId(int Value);
-            public sealed record Address(string City, string Street);
+                   public sealed record EntityId(int Value);
+                   public sealed record Address(string City, string Street);
 
-            [StaticDataRecord("Test", "TestSheet")]
-            public sealed record Entity(
-                EntityId Id,
-                string Name,
-                Address Location
-            );
-            """;
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record Entity(
+                       EntityId Id,
+                       string Name,
+                       Address Location
+                   );
+                   """;
 
         var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
         if (factory.CreateLogger<RecordSchemaParameterFlattenerTest>() is not TestOutputLogger<RecordSchemaParameterFlattenerTest> logger)

--- a/UnitTest/StaticDataTests/FilteredRecordTableTests.cs
+++ b/UnitTest/StaticDataTests/FilteredRecordTableTests.cs
@@ -1,11 +1,14 @@
 using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
 using Sdp.Attributes;
 using Sdp.Manager;
 using Sdp.Table;
+using UnitTest.Utility;
+using Xunit.Abstractions;
 
 namespace UnitTest.StaticDataTests;
 
-public class FilteredRecordTableTests
+public class FilteredRecordTableTests(ITestOutputHelper testOutputHelper)
 {
     private const string BuffCsv =
         """
@@ -25,7 +28,8 @@ public class FilteredRecordTableTests
     private sealed class AbnormalBuffTable(ImmutableList<Buff> records)
         : StaticDataTable<AbnormalBuffTable, Buff>(records.Where(x => !x.IsNormal).ToImmutableList());
 
-    private sealed class StaticData : StaticDataManager<StaticData.TableSet>
+    private sealed class StaticData(ILogger logger)
+        : StaticDataManager<StaticData.TableSet>(logger)
     {
         public sealed record TableSet(
             NormalBuffTable Normal,
@@ -43,7 +47,13 @@ public class FilteredRecordTableTests
         {
             WriteCsv(dir, "Buff.Main.csv", BuffCsv);
 
-            var staticData = new StaticData();
+            var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+            if (factory.CreateLogger<FilteredRecordTableTests>() is not TestOutputLogger<FilteredRecordTableTests> logger)
+            {
+                throw new InvalidOperationException("Logger creation failed.");
+            }
+
+            var staticData = new StaticData(logger);
             await staticData.LoadAsync(dir);
 
             Assert.Equal(2, staticData.NormalTable.Records.Count);
@@ -51,6 +61,7 @@ public class FilteredRecordTableTests
 
             Assert.Equal(2, staticData.AbnormalTable.Records.Count);
             Assert.All(staticData.AbnormalTable.Records, x => Assert.False(x.IsNormal));
+            Assert.Empty(logger.Logs);
         }
         finally
         {

--- a/UnitTest/StaticDataTests/SharedCsvTableTests.cs
+++ b/UnitTest/StaticDataTests/SharedCsvTableTests.cs
@@ -1,11 +1,14 @@
 using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
 using Sdp.Attributes;
 using Sdp.Manager;
 using Sdp.Table;
+using UnitTest.Utility;
+using Xunit.Abstractions;
 
 namespace UnitTest.StaticDataTests;
 
-public class SharedCsvTableTests
+public class SharedCsvTableTests(ITestOutputHelper testOutputHelper)
 {
     private const string UnitCsv =
         """
@@ -26,7 +29,8 @@ public class SharedCsvTableTests
     private sealed class UnitProfileTable(ImmutableList<UnitProfile> records)
         : StaticDataTable<UnitProfileTable, UnitProfile>(records);
 
-    private sealed class StaticData : StaticDataManager<StaticData.TableSet>
+    private sealed class StaticData(ILogger logger)
+        : StaticDataManager<StaticData.TableSet>(logger)
     {
         public sealed record TableSet(
             UnitStatTable Stats,
@@ -44,7 +48,13 @@ public class SharedCsvTableTests
         {
             WriteCsv(dir, "Unit.Main.csv", UnitCsv);
 
-            var staticData = new StaticData();
+            var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+            if (factory.CreateLogger<SharedCsvTableTests>() is not TestOutputLogger<SharedCsvTableTests> logger)
+            {
+                throw new InvalidOperationException("Logger creation failed.");
+            }
+
+            var staticData = new StaticData(logger);
             await staticData.LoadAsync(dir);
 
             Assert.Equal(2, staticData.StatTable.Records.Count);
@@ -54,6 +64,7 @@ public class SharedCsvTableTests
             Assert.Equal(2, staticData.ProfileTable.Records.Count);
             Assert.Equal("Goblin", staticData.ProfileTable.Records[0].Name);
             Assert.Equal("Small green creature", staticData.ProfileTable.Records[0].Description);
+            Assert.Empty(logger.Logs);
         }
         finally
         {

--- a/UnitTest/StaticDataTests/SharedRecordTableTests.cs
+++ b/UnitTest/StaticDataTests/SharedRecordTableTests.cs
@@ -1,11 +1,14 @@
 using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
 using Sdp.Attributes;
 using Sdp.Manager;
 using Sdp.Table;
+using UnitTest.Utility;
+using Xunit.Abstractions;
 
 namespace UnitTest.StaticDataTests;
 
-public class SharedRecordTableTests
+public class SharedRecordTableTests(ITestOutputHelper testOutputHelper)
 {
     private const string ItemCsv =
         """
@@ -44,7 +47,8 @@ public class SharedRecordTableTests
         public Item Get(string name) => byName.Get(name);
     }
 
-    private sealed class StaticData : StaticDataManager<StaticData.TableSet>
+    private sealed class StaticData(ILogger logger)
+        : StaticDataManager<StaticData.TableSet>(logger)
     {
         public sealed record TableSet(
             PrimaryItemTable Primary,
@@ -62,11 +66,18 @@ public class SharedRecordTableTests
         {
             WriteCsv(dir, "Item.Main.csv", ItemCsv);
 
-            var staticData = new StaticData();
+            var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+            if (factory.CreateLogger<SharedRecordTableTests>() is not TestOutputLogger<SharedRecordTableTests> logger)
+            {
+                throw new InvalidOperationException("Logger creation failed.");
+            }
+
+            var staticData = new StaticData(logger);
             await staticData.LoadAsync(dir);
 
             Assert.Equal("Beta", staticData.PrimaryTable.Get(2).Name);
             Assert.Equal(3, staticData.SecondaryTable.Get("Gamma").Id);
+            Assert.Empty(logger.Logs);
         }
         finally
         {

--- a/UnitTest/StaticDataTests/StaticDataManagerTests.cs
+++ b/UnitTest/StaticDataTests/StaticDataManagerTests.cs
@@ -1,13 +1,15 @@
 using System.Collections.Immutable;
 using System.Text;
+using Microsoft.Extensions.Logging;
 using Sdp.Attributes;
 using Sdp.Manager;
 using Sdp.Table;
 using UnitTest.Utility;
+using Xunit.Abstractions;
 
 namespace UnitTest.StaticDataTests;
 
-public class StaticDataManagerTests
+public class StaticDataManagerTests(ITestOutputHelper testOutputHelper)
 {
     [StaticDataRecord("Fake", "Sheet1")]
     private sealed record FakeRecord(int Id);
@@ -15,7 +17,8 @@ public class StaticDataManagerTests
     private sealed class FakeTable(ImmutableList<FakeRecord> records)
         : StaticDataTable<FakeTable, FakeRecord>(records);
 
-    private sealed class FakeManager : StaticDataManager<FakeManager.TableSet>
+    private sealed class FakeManager(ILogger logger)
+        : StaticDataManager<FakeManager.TableSet>(logger)
     {
         public sealed record TableSet(FakeTable? Items);
 
@@ -33,7 +36,13 @@ public class StaticDataManagerTests
         dirA.Write("Fake.Sheet1.csv", BuildCsv(CountA));
         dirB.Write("Fake.Sheet1.csv", BuildCsv(CountB));
 
-        var manager = new FakeManager();
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<StaticDataManagerTests>() is not TestOutputLogger<StaticDataManagerTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        var manager = new FakeManager(logger);
         await manager.LoadAsync(dirA.Path);
 
         var cts = new CancellationTokenSource();
@@ -60,6 +69,8 @@ public class StaticDataManagerTests
 
         cts.Cancel();
         loaderThread.Join();
+
+        Assert.Empty(logger.Logs);
     }
 
     private static string BuildCsv(int count)

--- a/UnitTest/Utility/TestOutputLogger.cs
+++ b/UnitTest/Utility/TestOutputLogger.cs
@@ -22,6 +22,11 @@ public class TestOutputLogger<T>(
     {
         ArgumentNullException.ThrowIfNull(formatter);
 
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
         var message = formatter(state, exception);
         if (!string.IsNullOrEmpty(message))
         {


### PR DESCRIPTION
StaticDataManager에 ILogger를 생성자 필수 주입으로 받도록 하고, 전체 LoadAsync 완료는 Information, 테이블별 완료는 Trace로 ms 단위 시간을 기록한다.                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                       
- 로그 메시지를 Messages.resx/Messages.ko.resx로 다국어화                                                                                                                                                                                                                                                                                                                                                               
- TestOutputLogger.Log에 IsEnabled 게이트를 추가해 minLogLevel 미만 로그를 캡처에서 제외                                                                                                                                                                                                                                                                                                                                
- Sdp 매니저 단위 테스트들을 TestOutputLogger 패턴으로 옮기고 logger.Logs 검증 추가                                                                                                                                                                                                                                                                                                                                     
- 유닛테스트 raw string literal의 시작/종료 컬럼이 어긋난 곳을 정렬 (스타일 정리)