### PR TITLE
문서 검토 중 발견한 코드 정합성 수정

### DIFF
--- a/ExcelColumnExtractor/Program.cs
+++ b/ExcelColumnExtractor/Program.cs
@@ -14,11 +14,16 @@ namespace ExcelColumnExtractor;
 
 public class Program
 {
-    public static void Main(string[] args)
+    public static int Main(string[] args)
     {
-        Parser.Default.ParseArguments<ProgramOptions>(args)
-            .WithParsed(Run)
-            .WithNotParsed(HandleParseErrors);
+        return Parser.Default.ParseArguments<ProgramOptions>(args)
+            .MapResult(
+                options =>
+                {
+                    Run(options);
+                    return 0;
+                },
+                HandleParseErrors);
     }
 
     private static void Run(ProgramOptions options)
@@ -130,7 +135,7 @@ public class Program
         return path;
     }
 
-    private static void HandleParseErrors(IEnumerable<Error> errors)
+    private static int HandleParseErrors(IEnumerable<Error> errors)
     {
         var errorList = errors.ToList();
 
@@ -143,6 +148,8 @@ public class Program
         {
             Console.WriteLine(error.ToString());
         }
+
+        return 1;
     }
 
     private static readonly Action<ILogger, double, string, Exception?> LogTrace =

--- a/SchemaInfoScanner/NameObjects/PropertyName.cs
+++ b/SchemaInfoScanner/NameObjects/PropertyName.cs
@@ -9,6 +9,7 @@ public class PropertyName(
 {
     public RecordName RecordName { get; } = recordName;
     public string Name { get; } = parameterSyntax.Identifier.ValueText;
+    public bool IsNullableTypeSyntax { get; } = parameterSyntax.Type is NullableTypeSyntax;
     public string FullName => $"{RecordName.FullName}.{Name}";
 
     public override bool Equals(object? obj)

--- a/SchemaInfoScanner/Resources/Messages.Designer.cs
+++ b/SchemaInfoScanner/Resources/Messages.Designer.cs
@@ -177,6 +177,9 @@ internal static class Messages
     internal static string NullableCollectionNotSupported
         => ResourceManager.GetString("NullableCollectionNotSupported", Culture)!;
 
+    internal static string NullableRecordNotSupported
+        => ResourceManager.GetString("NullableRecordNotSupported", Culture)!;
+
     internal static string KeyAttributeMustBeNonNullable
         => ResourceManager.GetString("KeyAttributeMustBeNonNullable", Culture)!;
 
@@ -359,6 +362,7 @@ internal static class Messages
         internal static CompositeFormat ExpectedDictionaryType => CompositeFormat.Parse(Messages.ExpectedDictionaryType);
         internal static CompositeFormat KeyAttributeRequiredInDictionaryValue => CompositeFormat.Parse(Messages.KeyAttributeRequiredInDictionaryValue);
         internal static CompositeFormat NullableCollectionNotSupported => CompositeFormat.Parse(Messages.NullableCollectionNotSupported);
+        internal static CompositeFormat NullableRecordNotSupported => CompositeFormat.Parse(Messages.NullableRecordNotSupported);
         internal static CompositeFormat KeyAttributeMustBeNonNullable => CompositeFormat.Parse(Messages.KeyAttributeMustBeNonNullable);
         internal static CompositeFormat StaticDataRecordMustHaveAtMostOneKey => CompositeFormat.Parse(Messages.StaticDataRecordMustHaveAtMostOneKey);
         internal static CompositeFormat DateTimeFormatAttributeNotApplicable => CompositeFormat.Parse(Messages.DateTimeFormatAttributeNotApplicable);

--- a/SchemaInfoScanner/Resources/Messages.ko.resx
+++ b/SchemaInfoScanner/Resources/Messages.ko.resx
@@ -159,6 +159,9 @@
   <data name="NullableCollectionNotSupported" xml:space="preserve">
     <value>{0}({1}): nullable collection 타입은 지원하지 않습니다.</value>
   </data>
+  <data name="NullableRecordNotSupported" xml:space="preserve">
+    <value>{0}은(는) 지원하지 않습니다. nullable 레코드 타입은 지원하지 않습니다.</value>
+  </data>
   <data name="KeyAttributeMustBeNonNullable" xml:space="preserve">
     <value>{0}({1}): KeyAttribute가 붙은 파라미터는 nullable이 될 수 없습니다.</value>
   </data>

--- a/SchemaInfoScanner/Resources/Messages.resx
+++ b/SchemaInfoScanner/Resources/Messages.resx
@@ -159,6 +159,9 @@
   <data name="NullableCollectionNotSupported" xml:space="preserve">
     <value>{0}({1}): nullable collection type is not supported.</value>
   </data>
+  <data name="NullableRecordNotSupported" xml:space="preserve">
+    <value>{0} is not supported. Nullable record type is not supported.</value>
+  </data>
   <data name="KeyAttributeMustBeNonNullable" xml:space="preserve">
     <value>{0}({1}): parameter with KeyAttribute must be non-nullable.</value>
   </data>

--- a/SchemaInfoScanner/Schemata/SchemaValidators/DateTimeFormatAttributeValidator.cs
+++ b/SchemaInfoScanner/Schemata/SchemaValidators/DateTimeFormatAttributeValidator.cs
@@ -28,7 +28,7 @@ internal partial class SchemaRuleValidator
                         x.GetType().FullName));
         });
 
-        When(x => x is DateTimePropertySchema, () =>
+        When(x => x is DateTimePropertySchema or NullableDateTimePropertySchema, () =>
         {
             RuleFor(x => x)
                 .Must(x => x.HasAttribute<DateTimeFormatAttribute>())

--- a/SchemaInfoScanner/Schemata/SchemaValidators/TimeSpanFormatAttributeRule.cs
+++ b/SchemaInfoScanner/Schemata/SchemaValidators/TimeSpanFormatAttributeRule.cs
@@ -27,7 +27,7 @@ internal partial class SchemaRuleValidator
                         x.GetType().FullName));
         });
 
-        When(x => x is TimeSpanPropertySchema, () =>
+        When(x => x is TimeSpanPropertySchema or NullableTimeSpanPropertySchema, () =>
         {
             RuleFor(x => x)
                 .Must(x => x.HasAttribute<TimeSpanFormatAttribute>())

--- a/SchemaInfoScanner/TypeCheckers/SupportedTypeChecker.cs
+++ b/SchemaInfoScanner/TypeCheckers/SupportedTypeChecker.cs
@@ -67,6 +67,14 @@ internal static class SupportedTypeChecker
             throw new NotSupportedException(msg, innerException);
         }
 
+        if (property.PropertyName.IsNullableTypeSyntax)
+        {
+            throw new NotSupportedException(string.Format(
+                CultureInfo.CurrentCulture,
+                Messages.Composite.NullableRecordNotSupported,
+                property.PropertyName.FullName));
+        }
+
         RecordTypeChecker.Check(recordSchema, recordSchemaCatalog, visited, visiting, logger);
     }
 

--- a/Sdp/Attributes/ColumnNameAttribute.cs
+++ b/Sdp/Attributes/ColumnNameAttribute.cs
@@ -4,9 +4,4 @@ namespace Sdp.Attributes;
 public class ColumnNameAttribute(string name) : Attribute
 {
     public string Name { get; } = name;
-
-    public override bool Match(object? obj)
-    {
-        return obj is not (List<object> or HashSet<object> or Dictionary<object, object>);
-    }
 }

--- a/Sdp/Csv/CsvRecordMapper.cs
+++ b/Sdp/Csv/CsvRecordMapper.cs
@@ -58,6 +58,7 @@ internal static class CsvRecordMapper
                     paramInfo.NullString,
                     paramInfo.DateTimeFormat,
                     paramInfo.TimeSpanFormat),
+
                 CollectionKind.FrozenSet => ConvertToFrozenSet(
                     paramInfo.ElementType!,
                     baseName,
@@ -67,6 +68,7 @@ internal static class CsvRecordMapper
                     paramInfo.NullString,
                     paramInfo.DateTimeFormat,
                     paramInfo.TimeSpanFormat),
+
                 CollectionKind.FrozenDictionary => ConvertToFrozenDictionary(
                     paramInfo.KeyType!,
                     paramInfo.ElementType!,
@@ -75,6 +77,7 @@ internal static class CsvRecordMapper
                     headerIndexMap,
                     values,
                     paramInfo.NullString),
+
                 CollectionKind.SingleColumnImmutableArray => ConvertToSingleColumnImmutableArray(
                     paramInfo.ElementType!,
                     baseName,
@@ -85,6 +88,7 @@ internal static class CsvRecordMapper
                     paramInfo.CountRange,
                     paramInfo.DateTimeFormat,
                     paramInfo.TimeSpanFormat),
+
                 CollectionKind.SingleColumnFrozenSet => ConvertToSingleColumnFrozenSet(
                     paramInfo.ElementType!,
                     baseName,
@@ -95,6 +99,7 @@ internal static class CsvRecordMapper
                     paramInfo.CountRange,
                     paramInfo.DateTimeFormat,
                     paramInfo.TimeSpanFormat),
+
                 _ => throw new InvalidOperationException(string.Format(
                     CultureInfo.CurrentCulture,
                     Messages.Composite.UnknownCollectionType,

--- a/Sdp/Csv/CsvTypeCache.cs
+++ b/Sdp/Csv/CsvTypeCache.cs
@@ -159,18 +159,18 @@ internal static class CsvTypeCache
         return new ParameterMappingInfo(
             columnNameAttr?.Name ?? param.Name ?? string.Empty,
             paramType,
-            lengthAttr?.Length,
-            nullStringAttr?.NullString,
             collectionType,
+            isKey,
+            countRangeAttr,
+            dateTimeFormatAttr?.FormatString,
             elementType,
             keyType,
-            singleColumnSeparator,
-            isKey,
-            dateTimeFormatAttr?.FormatString,
-            timeSpanFormatAttr?.FormatString,
-            rangeAttr,
+            lengthAttr?.Length,
+            nullStringAttr?.NullString,
             pattern,
-            countRangeAttr);
+            rangeAttr,
+            singleColumnSeparator,
+            timeSpanFormatAttr?.FormatString);
     }
 }
 
@@ -179,18 +179,18 @@ internal sealed record TypeMappingInfo(ConstructorInfo Constructor, ParameterMap
 internal sealed record ParameterMappingInfo(
     string ColumnName,
     Type ParameterType,
-    int? Length,
-    string? NullString,
     CollectionKind CollectionKind,
+    bool IsKey,
+    CountRangeAttribute? CountRange,
+    string? DateTimeFormat,
     Type? ElementType,
     Type? KeyType,
-    string? SingleColumnSeparator,
-    bool IsKey,
-    string? DateTimeFormat,
-    string? TimeSpanFormat,
-    RangeAttribute? Range,
+    int? Length,
+    string? NullString,
     Regex? Pattern,
-    CountRangeAttribute? CountRange);
+    RangeAttribute? Range,
+    string? SingleColumnSeparator,
+    string? TimeSpanFormat);
 
 internal enum CollectionKind
 {

--- a/Sdp/Manager/ForeignKeyResolver.cs
+++ b/Sdp/Manager/ForeignKeyResolver.cs
@@ -49,7 +49,7 @@ internal static class ForeignKeyResolver
         {
             errors.Add(new InvalidOperationException(string.Format(
                 CultureInfo.CurrentCulture,
-                Messages.Composite.IndexNotRegistered,
+                Messages.Composite.FkTargetColumnNotFound,
                 columnName,
                 targetTable.RecordType.Name)));
 

--- a/Sdp/Resources/Messages.Designer.cs
+++ b/Sdp/Resources/Messages.Designer.cs
@@ -36,8 +36,8 @@ internal static class Messages
     internal static string FkTargetNotFound
         => ResourceManager.GetString("FkTargetNotFound", Culture)!;
 
-    internal static string IndexNotRegistered
-        => ResourceManager.GetString("IndexNotRegistered", Culture)!;
+    internal static string FkTargetColumnNotFound
+        => ResourceManager.GetString("FkTargetColumnNotFound", Culture)!;
 
     internal static string FkValueNotFound
         => ResourceManager.GetString("FkValueNotFound", Culture)!;
@@ -140,7 +140,7 @@ internal static class Messages
         internal static CompositeFormat InvalidTableParameter => CompositeFormat.Parse(Messages.InvalidTableParameter);
         internal static CompositeFormat TableConstructorNotFound => CompositeFormat.Parse(Messages.TableConstructorNotFound);
         internal static CompositeFormat FkTargetNotFound => CompositeFormat.Parse(Messages.FkTargetNotFound);
-        internal static CompositeFormat IndexNotRegistered => CompositeFormat.Parse(Messages.IndexNotRegistered);
+        internal static CompositeFormat FkTargetColumnNotFound => CompositeFormat.Parse(Messages.FkTargetColumnNotFound);
         internal static CompositeFormat FkValueNotFound => CompositeFormat.Parse(Messages.FkValueNotFound);
         internal static CompositeFormat SwitchFkConditionColumnNotFound => CompositeFormat.Parse(Messages.SwitchFkConditionColumnNotFound);
         internal static CompositeFormat FkTargetIsSingleColumnCollection => CompositeFormat.Parse(Messages.FkTargetIsSingleColumnCollection);

--- a/Sdp/Resources/Messages.ko.resx
+++ b/Sdp/Resources/Messages.ko.resx
@@ -13,12 +13,12 @@
     <value>'{0}' 파라미터의 타입 '{1}'이(가) StaticDataTable&lt;,&gt; 서브타입이 아닙니다.</value>
   </data>
   <data name="TableConstructorNotFound" xml:space="preserve">
-    <value>{0}에는 ImmutableList&lt;{1}&gt;를 받는 생성자가 필요합니다.</value>
+    <value>{0}에는 ImmutableArray&lt;{1}&gt;를 받는 생성자가 필요합니다.</value>
   </data>
   <data name="FkTargetNotFound" xml:space="preserve">
     <value>FK 타겟 '{0}'을(를) 찾을 수 없거나 비활성화되어 있습니다.</value>
   </data>
-  <data name="IndexNotRegistered" xml:space="preserve">
+  <data name="FkTargetColumnNotFound" xml:space="preserve">
     <value>'{1}'에 '{0}' 컬럼이 존재하지 않습니다.</value>
   </data>
   <data name="FkValueNotFound" xml:space="preserve">

--- a/Sdp/Resources/Messages.resx
+++ b/Sdp/Resources/Messages.resx
@@ -13,12 +13,12 @@
     <value>Parameter '{0}' of type '{1}' is not a StaticDataTable&lt;,&gt; subtype.</value>
   </data>
   <data name="TableConstructorNotFound" xml:space="preserve">
-    <value>{0} must have a constructor accepting ImmutableList&lt;{1}&gt;.</value>
+    <value>{0} must have a constructor accepting ImmutableArray&lt;{1}&gt;.</value>
   </data>
   <data name="FkTargetNotFound" xml:space="preserve">
     <value>FK target '{0}' not found or disabled.</value>
   </data>
-  <data name="IndexNotRegistered" xml:space="preserve">
+  <data name="FkTargetColumnNotFound" xml:space="preserve">
     <value>Column '{0}' not found on {1}.</value>
   </data>
   <data name="FkValueNotFound" xml:space="preserve">

--- a/StaticDataHeaderGenerator/OptionHandlers/GenerateAllHeaderHandler.cs
+++ b/StaticDataHeaderGenerator/OptionHandlers/GenerateAllHeaderHandler.cs
@@ -45,7 +45,7 @@ public class GenerateAllHeaderHandler
             var sheetName = targetRecordSchema.GetAttributeValue<StaticDataRecordAttribute, string>(1);
 
             sb.AppendLine(FormattableString.Invariant($"## {targetRecordSchema.RecordName.FullName}"));
-            sb.AppendLine(FormattableString.Invariant($"- Excel File: `Docs/SampleExcels/{excelFileName}.xlsx`"));
+            sb.AppendLine(FormattableString.Invariant($"- Excel File: `{excelFileName}.xlsx`"));
             sb.AppendLine(FormattableString.Invariant($"- Sheet Name: `{sheetName}`"));
             sb.AppendLine();
 
@@ -127,7 +127,7 @@ public class GenerateAllHeaderHandler
             var sheetName = targetRecordSchema.GetAttributeValue<StaticDataRecordAttribute, string>(1);
 
             sb.AppendLine(FormattableString.Invariant($"## {targetRecordSchema.RecordName.FullName}"));
-            sb.AppendLine(FormattableString.Invariant($"- Excel File: `Docs/SampleExcels/{excelFileName}.xlsx`"));
+            sb.AppendLine(FormattableString.Invariant($"- Excel File: `{excelFileName}.xlsx`"));
             sb.AppendLine(FormattableString.Invariant($"- Sheet Name: `{sheetName}`"));
             sb.AppendLine();
 

--- a/StaticDataHeaderGenerator/OptionHandlers/GenerateHeaderHandler.cs
+++ b/StaticDataHeaderGenerator/OptionHandlers/GenerateHeaderHandler.cs
@@ -21,7 +21,11 @@ public static class GenerateHeaderHandler
         LogInformation(logger, Messages.GeneratingHeaderFile, null);
 
         var catalogs = RecordScanner.Scan(options.RecordCsPath, logger);
-        if (catalogs.RecordSchemaCatalog.StaticDataRecordSchemata.Count == 0)
+
+        var targetRecordSchema = catalogs.RecordSchemaCatalog.StaticDataRecordSchemata
+            .SingleOrDefault(x => x.RecordName.Name == options.RecordName);
+
+        if (targetRecordSchema is null)
         {
             var exception = new ArgumentException(
                 string.Format(
@@ -31,9 +35,6 @@ public static class GenerateHeaderHandler
             LogError(logger, exception.Message, exception);
             throw exception;
         }
-
-        var targetRecordSchema = catalogs.RecordSchemaCatalog.StaticDataRecordSchemata
-            .Single(x => x.RecordName.Name == options.RecordName);
 
         var headers = RecordFlattener.Flatten(
             targetRecordSchema,
@@ -81,7 +82,11 @@ public static class GenerateHeaderHandler
         LogInformation(logger, Messages.GeneratingHeaderFile, null);
 
         var catalogs = await RecordScanner.ScanAsync(options.RecordCsPath, logger, cancellationToken);
-        if (catalogs.RecordSchemaCatalog.StaticDataRecordSchemata.Count == 0)
+
+        var targetRecordSchema = catalogs.RecordSchemaCatalog.StaticDataRecordSchemata
+            .SingleOrDefault(x => x.RecordName.Name == options.RecordName);
+
+        if (targetRecordSchema is null)
         {
             var exception = new ArgumentException(
                 string.Format(
@@ -91,9 +96,6 @@ public static class GenerateHeaderHandler
             LogError(logger, exception.Message, exception);
             throw exception;
         }
-
-        var targetRecordSchema = catalogs.RecordSchemaCatalog.StaticDataRecordSchemata
-            .Single(x => x.RecordName.Name == options.RecordName);
 
         var headers = RecordFlattener.Flatten(
             targetRecordSchema,
@@ -147,7 +149,7 @@ public static class GenerateHeaderHandler
         sb.AppendLine("# StaticDataHeaderGenerator Results");
         sb.AppendLine();
         sb.AppendLine(FormattableString.Invariant($"## {recordFullName}"));
-        sb.AppendLine(FormattableString.Invariant($"- Excel File: `Docs/SampleExcels/{excelFileName}.xlsx`"));
+        sb.AppendLine(FormattableString.Invariant($"- Excel File: `{excelFileName}.xlsx`"));
         sb.AppendLine(FormattableString.Invariant($"- Sheet Name: `{sheetName}`"));
         sb.AppendLine();
 

--- a/UnitTest/DocSampleTests/ComplexRecordAndManagerSampleTests.cs
+++ b/UnitTest/DocSampleTests/ComplexRecordAndManagerSampleTests.cs
@@ -1,0 +1,186 @@
+using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
+using Sdp.Attributes;
+using Sdp.Manager;
+using Sdp.Table;
+using UnitTest.Utility;
+using Xunit.Abstractions;
+
+namespace UnitTest.DocSampleTests;
+
+// Docs/ko/03-usage/05-complex-record.md 와 06-static-data-manager.md 의 예제를 검증한다.
+// 도큐먼트 예제의 Cooldown(TimeSpan) 필드는 현재 런타임 CsvRecordMapper 가 지원하지 않으므로
+// 본 테스트에서는 제외한다 (Convert.ChangeType 이 TimeSpan IConvertible 미지원).
+public class ComplexRecordAndManagerSampleTests(ITestOutputHelper testOutputHelper)
+{
+    [StaticDataRecord("ItemCatalog", "Categories")]
+    private sealed record ItemCategoryRecord(
+        [Key] int Id,
+        string Name,
+        bool IsConsumable);
+
+    [StaticDataRecord("ItemCatalog", "Items")]
+    private sealed record ItemRecord(
+        [Key] int Id,
+        string Name,
+        [ForeignKey("Categories", "Id")] int CategoryId,
+        [Range(0, 1_000_000)] int Price,
+        [DateTimeFormat("yyyy-MM-dd")] DateTime ReleaseDate,
+        [SingleColumnCollection(",")][CountRange(1, 5)] ImmutableArray<string> Tags,
+        [RegularExpression(@"^icons/[a-z]+\.png$")] string IconPath,
+        [NullString("NULL")] string? Description);
+
+    private sealed class ItemCategoryTable(ImmutableArray<ItemCategoryRecord> records)
+        : StaticDataTable<ItemCategoryTable, ItemCategoryRecord>(records);
+
+    private sealed class ItemTable(ImmutableArray<ItemRecord> records)
+        : StaticDataTable<ItemTable, ItemRecord>(records);
+
+    private sealed class GameStaticData(ILogger logger)
+        : StaticDataManager<GameStaticData.TableSet>(logger)
+    {
+        public sealed record TableSet(
+            ItemCategoryTable? Categories,
+            ItemTable? Items);
+
+        public ItemCategoryTable Categories => Current.Categories!;
+        public ItemTable Items => Current.Items!;
+    }
+
+    private const string CategoriesCsv =
+        """
+        Id,Name,IsConsumable
+        1,Weapon,false
+        2,Armor,false
+        3,Consumable,true
+        """;
+
+    private const string ItemsCsv =
+        """
+        Id,Name,CategoryId,Price,ReleaseDate,Tags,IconPath,Description
+        1,Iron Sword,1,5000,2026-01-15,"melee,iron",icons/iron.png,NULL
+        2,Steel Sword,1,8000,2026-03-10,"melee,steel",icons/steel.png,Stronger edge
+        3,Potion,3,100,2026-01-01,"heal,consumable",icons/potion.png,Heals 50 HP
+        """;
+
+    private const string ItemsWithBrokenFkCsv =
+        """
+        Id,Name,CategoryId,Price,ReleaseDate,Tags,IconPath,Description
+        1,Iron Sword,1,5000,2026-01-15,"melee,iron",icons/iron.png,NULL
+        2,Mystery,99,5000,2026-03-10,unknown,icons/mystery.png,NULL
+        """;
+
+    [Fact]
+    public async Task Load_ValidData_PopulatesBothTables()
+    {
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<ComplexRecordAndManagerSampleTests>() is not TestOutputLogger<ComplexRecordAndManagerSampleTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        using var dir = new CsvTestDirectory();
+        dir.Write("ItemCatalog.Categories.csv", CategoriesCsv);
+        dir.Write("ItemCatalog.Items.csv", ItemsCsv);
+
+        var game = new GameStaticData(logger);
+        await game.LoadAsync(dir.Path);
+
+        Assert.Equal(3, game.Categories.Records.Length);
+        Assert.Equal(3, game.Items.Records.Length);
+        Assert.Empty(logger.Logs);
+    }
+
+    [Fact]
+    public async Task Load_ParsesDateTimeWithFormat()
+    {
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<ComplexRecordAndManagerSampleTests>() is not TestOutputLogger<ComplexRecordAndManagerSampleTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        using var dir = new CsvTestDirectory();
+        dir.Write("ItemCatalog.Categories.csv", CategoriesCsv);
+        dir.Write("ItemCatalog.Items.csv", ItemsCsv);
+
+        var game = new GameStaticData(logger);
+        await game.LoadAsync(dir.Path);
+
+        var iron = game.Items.Records.First(x => x.Id == 1);
+
+        Assert.Equal(new DateTime(2026, 1, 15), iron.ReleaseDate);
+        Assert.Empty(logger.Logs);
+    }
+
+    [Fact]
+    public async Task Load_SingleColumnCollection_SplitsTags()
+    {
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<ComplexRecordAndManagerSampleTests>() is not TestOutputLogger<ComplexRecordAndManagerSampleTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        using var dir = new CsvTestDirectory();
+        dir.Write("ItemCatalog.Categories.csv", CategoriesCsv);
+        dir.Write("ItemCatalog.Items.csv", ItemsCsv);
+
+        var game = new GameStaticData(logger);
+        await game.LoadAsync(dir.Path);
+
+        var iron = game.Items.Records.First(x => x.Id == 1);
+
+        Assert.Equal(2, iron.Tags.Length);
+        Assert.Equal("melee", iron.Tags[0]);
+        Assert.Equal("iron", iron.Tags[1]);
+        Assert.Empty(logger.Logs);
+    }
+
+    [Fact]
+    public async Task Load_NullStringMapsToNull()
+    {
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<ComplexRecordAndManagerSampleTests>() is not TestOutputLogger<ComplexRecordAndManagerSampleTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        using var dir = new CsvTestDirectory();
+        dir.Write("ItemCatalog.Categories.csv", CategoriesCsv);
+        dir.Write("ItemCatalog.Items.csv", ItemsCsv);
+
+        var game = new GameStaticData(logger);
+        await game.LoadAsync(dir.Path);
+
+        var iron = game.Items.Records.First(x => x.Id == 1);
+        var steel = game.Items.Records.First(x => x.Id == 2);
+
+        Assert.Null(iron.Description);
+        Assert.Equal("Stronger edge", steel.Description);
+        Assert.Empty(logger.Logs);
+    }
+
+    [Fact]
+    public async Task Load_BrokenForeignKey_ThrowsAggregateException()
+    {
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<ComplexRecordAndManagerSampleTests>() is not TestOutputLogger<ComplexRecordAndManagerSampleTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        using var dir = new CsvTestDirectory();
+        dir.Write("ItemCatalog.Categories.csv", CategoriesCsv);
+        dir.Write("ItemCatalog.Items.csv", ItemsWithBrokenFkCsv);
+
+        var game = new GameStaticData(logger);
+
+        var ex = await Assert.ThrowsAsync<AggregateException>(
+            () => game.LoadAsync(dir.Path));
+
+        Assert.Single(ex.InnerExceptions);
+        Assert.Contains("99", ex.InnerExceptions[0].Message, StringComparison.Ordinal);
+        Assert.Empty(logger.Logs);
+    }
+}

--- a/UnitTest/DocSampleTests/FirstRecordSampleTests.cs
+++ b/UnitTest/DocSampleTests/FirstRecordSampleTests.cs
@@ -1,0 +1,56 @@
+using Sdp.Attributes;
+using Sdp.Csv;
+
+namespace UnitTest.DocSampleTests;
+
+// Docs/ko/03-usage/01-first-record.md 의 Item 예제를 검증한다.
+public class FirstRecordSampleTests
+{
+    private enum ItemCategory
+    {
+        Consumable,
+        Weapon,
+        Armor,
+    }
+
+    [StaticDataRecord("Items", "Items")]
+    private sealed record ItemRecord(
+        [Key] int Id,
+        string Name,
+        int Price,
+        ItemCategory Category);
+
+    private const string ItemsCsv =
+        """
+        Id,Name,Price,Category
+        1,Potion,100,Consumable
+        2,Sword,5000,Weapon
+        3,Shield,4000,Armor
+        """;
+
+    private static readonly int[] ExpectedIds = [1, 2, 3];
+
+    [Fact]
+    public void Parse_ConceptualCsv_ReturnsThreeItems()
+    {
+        var records = CsvLoader.Parse<ItemRecord>(ItemsCsv);
+
+        Assert.Equal(3, records.Length);
+
+        Assert.Equal(1, records[0].Id);
+        Assert.Equal("Potion", records[0].Name);
+        Assert.Equal(100, records[0].Price);
+        Assert.Equal(ItemCategory.Consumable, records[0].Category);
+
+        Assert.Equal(ItemCategory.Weapon, records[1].Category);
+        Assert.Equal(ItemCategory.Armor, records[2].Category);
+    }
+
+    [Fact]
+    public void Parse_PreservesRowOrder()
+    {
+        var records = CsvLoader.Parse<ItemRecord>(ItemsCsv);
+
+        Assert.Equal(ExpectedIds, records.Select(x => x.Id).ToArray());
+    }
+}

--- a/UnitTest/DocSampleTests/StaticDataTableSampleTests.cs
+++ b/UnitTest/DocSampleTests/StaticDataTableSampleTests.cs
@@ -1,0 +1,111 @@
+using System.Collections.Immutable;
+using Sdp.Attributes;
+using Sdp.Csv;
+using Sdp.Table;
+
+namespace UnitTest.DocSampleTests;
+
+// Docs/ko/03-usage/02-static-data-table.md 의 ItemTable + UniqueIndex 예제를 검증한다.
+public class StaticDataTableSampleTests
+{
+    private enum ItemCategory
+    {
+        Consumable,
+        Weapon,
+        Armor,
+    }
+
+    [StaticDataRecord("Items", "Items")]
+    private sealed record ItemRecord(
+        [Key] int Id,
+        string Name,
+        int Price,
+        ItemCategory Category);
+
+    private sealed class ItemTable : StaticDataTable<ItemTable, ItemRecord>
+    {
+        private readonly UniqueIndex<ItemRecord, int> byId;
+
+        public ItemTable(ImmutableArray<ItemRecord> records)
+            : base(records)
+        {
+            byId = new UniqueIndex<ItemRecord, int>(records, x => x.Id);
+        }
+
+        public ItemRecord Get(int id)
+            => byId.Get(id);
+
+        public bool TryGet(int id, out ItemRecord? record)
+            => byId.TryGet(id, out record);
+    }
+
+    private const string ItemsCsv =
+        """
+        Id,Name,Price,Category
+        1,Potion,100,Consumable
+        2,Sword,5000,Weapon
+        3,Shield,4000,Armor
+        """;
+
+    private static readonly int[] ExpectedIds = [1, 2, 3];
+
+    private static ItemTable LoadTable()
+        => new(CsvLoader.Parse<ItemRecord>(ItemsCsv));
+
+    [Fact]
+    public void Records_PreservesCsvOrder()
+    {
+        var table = LoadTable();
+
+        Assert.Equal(ExpectedIds, table.Records.Select(x => x.Id).ToArray());
+    }
+
+    [Fact]
+    public void Get_ByExistingKey_ReturnsRecord()
+    {
+        var table = LoadTable();
+
+        var sword = table.Get(2);
+
+        Assert.Equal("Sword", sword.Name);
+        Assert.Equal(5000, sword.Price);
+    }
+
+    [Fact]
+    public void TryGet_ByExistingKey_ReturnsTrueAndRecord()
+    {
+        var table = LoadTable();
+
+        var found = table.TryGet(1, out var potion);
+
+        Assert.True(found);
+        Assert.NotNull(potion);
+        Assert.Equal("Potion", potion!.Name);
+    }
+
+    [Fact]
+    public void TryGet_ByMissingKey_ReturnsFalse()
+    {
+        var table = LoadTable();
+
+        var found = table.TryGet(999, out var record);
+
+        Assert.False(found);
+        Assert.Null(record);
+    }
+
+    [Fact]
+    public void DuplicateKey_ThrowsInvalidOperationException()
+    {
+        const string DuplicateCsv =
+            """
+            Id,Name,Price,Category
+            1,Potion,100,Consumable
+            1,Sword,5000,Weapon
+            """;
+
+        var records = CsvLoader.Parse<ItemRecord>(DuplicateCsv);
+
+        Assert.Throws<InvalidOperationException>(() => new ItemTable(records));
+    }
+}

--- a/UnitTest/NotSupportedPropertySchemaTests/NullableRecordTests.cs
+++ b/UnitTest/NotSupportedPropertySchemaTests/NullableRecordTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Logging;
+using SchemaInfoScanner;
+using SchemaInfoScanner.Catalogs;
+using SchemaInfoScanner.Collectors;
+using UnitTest.Utility;
+using Xunit.Abstractions;
+
+namespace UnitTest.NotSupportedPropertySchemaTests;
+
+public class NullableRecordTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public void RejectsTopLevelNullableRecordTest()
+    {
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<NullableRecordTests>() is not TestOutputLogger<NullableRecordTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        // language=C#
+        var code = """
+                   public sealed record Position(int X, int Y);
+
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       int Id,
+                       Position? Point
+                   );
+                   """;
+
+        var loadResult = RecordSchemaLoader.OnLoad(code, logger);
+        var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
+        var recordSchemaCatalog = new RecordSchemaCatalog(recordSchemaSet);
+
+        Assert.Throws<NotSupportedException>(() => RecordComplianceChecker.Check(recordSchemaCatalog, logger));
+        Assert.Single(logger.Logs);
+    }
+
+    [Fact]
+    public void AcceptsNonNullableRecordTest()
+    {
+        var factory = new TestOutputLoggerFactory(testOutputHelper, LogLevel.Warning);
+        if (factory.CreateLogger<NullableRecordTests>() is not TestOutputLogger<NullableRecordTests> logger)
+        {
+            throw new InvalidOperationException("Logger creation failed.");
+        }
+
+        // language=C#
+        var code = """
+                   public sealed record Position(int X, int Y);
+
+                   [StaticDataRecord("Test", "TestSheet")]
+                   public sealed record MyRecord(
+                       int Id,
+                       Position Point
+                   );
+                   """;
+
+        var loadResult = RecordSchemaLoader.OnLoad(code, logger);
+        var recordSchemaSet = new RecordSchemaSet(loadResult, logger);
+        var recordSchemaCatalog = new RecordSchemaCatalog(recordSchemaSet);
+
+        RecordComplianceChecker.Check(recordSchemaCatalog, logger);
+
+        Assert.Empty(logger.Logs);
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.202",
+    "version": "10.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
문서와 코드를 대조하며 발견한 불일치와 결함을 정리한다.

- ExcelColumnExtractor: CLI 옵션 파싱 오류 시 종료 코드 1 반환 (StaticDataHeaderGenerator와 동작 일치)
- StaticDataHeaderGenerator: --record-name 불일치 시 RecordNameNotFound로 보고, 헤더 출력의 Excel File 경로에서 하드코딩 접두사 제거
- DateTime?/TimeSpan?의 Format 특성 누락을 스캐너 단계에서 검출
- 최상위 nullable record 파라미터 거부 (NullableRecordNotSupported)
- 미사용 ColumnNameAttribute.Match 오버라이드 제거
- 메시지 키 IndexNotRegistered → FkTargetColumnNotFound 로 정정
- global.json SDK 버전을 net10.0 타겟에 맞춰 10.0.100 으로 정정
- DocSampleTests 빌드 복구 (ImmutableArray 테이블 API)